### PR TITLE
Ssh timeout

### DIFF
--- a/terraform/modules/AWS/Bastion/cloud-config.yaml
+++ b/terraform/modules/AWS/Bastion/cloud-config.yaml
@@ -103,7 +103,9 @@ write_files:
       X11DisplayOffset 10
       PrintMotd no
       PrintLastLog yes
-      TCPKeepAlive no
+      TCPKeepAlive no 
+      ClientAliveInterval 30
+      ClientAliveCountMax 240
       # Allow SendEnv of BASE64_SSH_KEY to enable SSHing to the instances in the
       # private subnet (the kubernetes master and nodes)
       AcceptEnv BASE64_SSH_KEY LANG LC_*

--- a/terraform/modules/AWS/Bastion/cloud-config.yaml
+++ b/terraform/modules/AWS/Bastion/cloud-config.yaml
@@ -103,7 +103,7 @@ write_files:
       X11DisplayOffset 10
       PrintMotd no
       PrintLastLog yes
-      TCPKeepAlive yes
+      TCPKeepAlive no
       # Allow SendEnv of BASE64_SSH_KEY to enable SSHing to the instances in the
       # private subnet (the kubernetes master and nodes)
       AcceptEnv BASE64_SSH_KEY LANG LC_*


### PR DESCRIPTION
disable TcpKeepAlive is sshd config and add ClientAliveInterval and ClientAliveCountMax to the config, increased the client timeout to 2 hours
