### PR TITLE
feat: move detection of SSH and IP

### DIFF
--- a/pkg/simulator/terraform.go
+++ b/pkg/simulator/terraform.go
@@ -47,8 +47,24 @@ func Terraform(wd, cmd, bucket string) (*string, error) {
 func InitIfNeeded(logger *zap.SugaredLogger, tfDir, bucket string) error {
 	logger.Debug("Terraform.InitIfNeeded() start")
 
+	logger.Info("Running terraform init")
+	_, err := Terraform(tfDir, "init", bucket)
+	if err != nil {
+		return errors.Wrap(err, "Error initialising terraform")
+	}
+
+	return nil
+}
+
+// -#-
+
+// Create runs terraform init, plan, apply to create the necessary
+// infrastructure to run scenarios
+func Create(logger *zap.SugaredLogger, tfDir, bucket string) error {
+	err := InitIfNeeded(logger, tfDir, bucket)
+
 	logger.Info("Ensuring there is a simulator keypair")
-	_, err := ssh.EnsureKey()
+	_, err = ssh.EnsureKey()
 	if err != nil {
 		return errors.Wrap(err, "Error ensuring SSH key")
 	}
@@ -75,22 +91,6 @@ func InitIfNeeded(logger *zap.SugaredLogger, tfDir, bucket string) error {
 	if err != nil {
 		return errors.Wrap(err, "Error writing tfvars")
 	}
-
-	logger.Info("Running terraform init")
-	_, err = Terraform(tfDir, "init", bucket)
-	if err != nil {
-		return errors.Wrap(err, "Error initialising terraform")
-	}
-
-	return nil
-}
-
-// -#-
-
-// Create runs terraform init, plan, apply to create the necessary
-// infrastructure to run scenarios
-func Create(logger *zap.SugaredLogger, tfDir, bucket string) error {
-	err := InitIfNeeded(logger, tfDir, bucket)
 
 	if err != nil {
 		return err


### PR DESCRIPTION
This moves the change detection out of `InitIfNeeded` which is always run before any command which interacts with infrastructure to only run when running `simulator infra create`