### PR TITLE
Dev tools

### DIFF
--- a/tools/migrate-hints/lib/io.js
+++ b/tools/migrate-hints/lib/io.js
@@ -1,0 +1,32 @@
+const yaml = require('js-yaml')
+const {truncateSync, writeFileSync, readFileSync, readdirSync} = require('fs')
+const {resolve,join} = require('path')
+const {transformV0ToV1} = require('../lib/transforms')
+
+// Loads and parses a `hints.yaml` from the supplied absolute path. 
+// Returns an object representing the yaml file
+module.exports.loadHintsFile = p => {
+  console.log(`Loading ${p}`)
+  const doc = yaml.safeLoad(readFileSync(p, 'utf8'));
+  return doc
+}
+
+// Serializes the supplied `hints` to YAML and overwrites an existing 
+// `hints.yaml` file to the supplied path `p` with the YAMl
+module.exports.writeHintsFile = (hints, p) => {
+  console.log(`Writing transformed file ${p}`)
+  const contents = yaml.safeDump(hints)
+  truncateSync(p)
+  writeFileSync(p, contents)
+}
+
+// Given a relative path to a scenario directory, scans for scenarios
+// Returns a list of absolute paths to all `hints.yaml` files
+module.exports.findScenarioHintsFiles = scenariosDir => {
+  const absPath = resolve(scenariosDir)
+
+  return readdirSync(absPath, { withFileTypes: true })
+    .filter(dirent => dirent.isDirectory())
+    .map(dirent => join(absPath, dirent.name, 'hints.yaml'))
+}
+

--- a/tools/migrate-hints/lib/transforms.js
+++ b/tools/migrate-hints/lib/transforms.js
@@ -3,11 +3,13 @@ module.exports.groupHintsByTask = groupHintsByTask = (hints) => {
     // Pull apart the hint text on the first colon
     const [task, hintText] = hint.text.split(': ', 2)
 
+    const sortOrder = Number(task[task.length - 1])
+
     // Create a new group for the task if it doesn't exist
-    if (!acc[task]) acc[task] = []
+    if (!acc[task]) acc[task] = { "sort-order": sortOrder, hints: []}
 
     // Reconstruct a hint without the task prefix and add it to the group
-    acc[task].push({ text: hintText })
+    acc[task].hints.push({ text: hintText })
 
     return acc
   }, {})
@@ -31,7 +33,7 @@ module.exports.transformV0ToV1 = hints => {
       return acc
     }, [])
 
-  transformed.hints = groupHintsByTask(hintsList)
+  transformed.tasks = groupHintsByTask(hintsList)
 
   return transformed
 }

--- a/tools/migrate-hints/lib/transforms.js
+++ b/tools/migrate-hints/lib/transforms.js
@@ -1,4 +1,4 @@
-module.exports.groupHintsByTask = (hints) => {
+module.exports.groupHintsByTask = groupHintsByTask = (hints) => {
   return hints.reduce((acc, hint) => {
     // Pull apart the hint text on the first colon
     const [task, hintText] = hint.text.split(': ', 2)
@@ -31,9 +31,7 @@ module.exports.transformV0ToV1 = hints => {
       return acc
     }, [])
 
-  // TODO: split string on prefix and nest task hints under hints?
-
-  transformed.hints = hintsList
+  transformed.hints = groupHintsByTask(hintsList)
 
   return transformed
 }

--- a/tools/migrate-hints/lib/transforms.js
+++ b/tools/migrate-hints/lib/transforms.js
@@ -1,0 +1,39 @@
+module.exports.groupHintsByTask = (hints) => {
+  return hints.reduce((acc, hint) => {
+    // Pull apart the hint text on the first colon
+    const [task, hintText] = hint.text.split(': ', 2)
+
+    // Create a new group for the task if it doesn't exist
+    if (!acc[task]) acc[task] = []
+
+    // Reconstruct a hint without the task prefix and add it to the group
+    acc[task].push({ text: hintText })
+
+    return acc
+  }, {})
+}
+
+// Takes an array of top level yaml properties represented as a JS object and
+// Returns a transformed array of top-level properties in the new format
+module.exports.transformV0ToV1 = hints => {
+  const transformed = {}
+  // remove hint count
+  delete hints[0]['general_overview']["num-hints"]
+
+  transformed['general_overview'] = hints[0]['general_overview']
+  // add version
+  transformed.kind = 'cp.simulator/scenario:1.0.0'
+
+  // transform hints
+  const hintsList  = Object.entries(hints[1].hints)
+    .reduce((acc, [key, val], idx) => { 
+      acc.push({ text: val })
+      return acc
+    }, [])
+
+  // TODO: split string on prefix and nest task hints under hints?
+
+  transformed.hints = hintsList
+
+  return transformed
+}

--- a/tools/migrate-hints/test/transforms_test.js
+++ b/tools/migrate-hints/test/transforms_test.js
@@ -25,8 +25,8 @@ test('transforms v0 to v1 schema', t => {
       }
     }, {
       hints: {
-        "hint-1": "test hint 1",
-        "hint-2": "test hint 2"
+        "hint-1": "Task 1: test hint 1",
+        "hint-2": "Task 1: test hint 2"
       }
     }
   ]
@@ -37,7 +37,9 @@ test('transforms v0 to v1 schema', t => {
       objective: "test objective",
       "starting-point": "kubectl pod exec."
     },
-    hints: [ { "text": "test hint 1" }, { "text": "test hint 2" } ]
+    hints: {
+      "Task 1": [ { "text": "test hint 1" }, { "text": "test hint 2" } ]
+    }
   }
 
   t.deepEqual(transformV0ToV1(original), expected)

--- a/tools/migrate-hints/test/transforms_test.js
+++ b/tools/migrate-hints/test/transforms_test.js
@@ -31,16 +31,14 @@ test('transforms v0 to v1 schema', t => {
     }
   ]
 
-  const expected = [{
-      kind: "cp.simulator/scenario:1.0.0",
-    }, {
-      general_overview: {
-        objective: "test objective",
-        "starting-point": "kubectl pod exec."
-      }
-    }, {
+  const expected = {
+    kind: "cp.simulator/scenario:1.0.0",
+    general_overview: {
+      objective: "test objective",
+      "starting-point": "kubectl pod exec."
+    },
     hints: [ { "text": "test hint 1" }, { "text": "test hint 2" } ]
-    }]
+  }
 
   t.deepEqual(transformV0ToV1(original), expected)
 })

--- a/tools/migrate-hints/test/transforms_test.js
+++ b/tools/migrate-hints/test/transforms_test.js
@@ -2,15 +2,21 @@ const test = require('ava')
 const {transformV0ToV1, groupHintsByTask} = require('../lib/transforms')
 
 test('groupHintsByTask', t => {
-  const original = [ 
-    { text: 'Task 1: test hint' }, 
+  const original = [
+    { text: 'Task 1: test hint' },
     { text: 'Task 1: test hint' },
     { text: 'Task 2: test hint' }
   ]
 
   const expected = {
-    "Task 1": [ { text: "test hint" }, { text: "test hint" } ],
-    "Task 2": [ { text: "test hint" } ]
+    "Task 1": {
+      "sort-order": 1,
+      hints: [ { text: "test hint" }, { text: "test hint" } ],
+    },
+    "Task 2": {
+      "sort-order": 2,
+      hints: [ { text: "test hint" } ]
+    }
   }
 
   t.deepEqual(groupHintsByTask(original), expected)
@@ -37,8 +43,11 @@ test('transforms v0 to v1 schema', t => {
       objective: "test objective",
       "starting-point": "kubectl pod exec."
     },
-    hints: {
-      "Task 1": [ { "text": "test hint 1" }, { "text": "test hint 2" } ]
+    tasks: {
+      "Task 1": {
+        "sort-order": 1,
+        hints: [ { "text": "test hint 1" }, { "text": "test hint 2" } ]
+      }
     }
   }
 

--- a/tools/migrate-hints/test/transforms_test.js
+++ b/tools/migrate-hints/test/transforms_test.js
@@ -1,5 +1,20 @@
 const test = require('ava')
-const {transformV0ToV1} = require('../lib/transforms')
+const {transformV0ToV1, groupHintsByTask} = require('../lib/transforms')
+
+test('groupHintsByTask', t => {
+  const original = [ 
+    { text: 'Task 1: test hint' }, 
+    { text: 'Task 1: test hint' },
+    { text: 'Task 2: test hint' }
+  ]
+
+  const expected = {
+    "Task 1": [ { text: "test hint" }, { text: "test hint" } ],
+    "Task 2": [ { text: "test hint" } ]
+  }
+
+  t.deepEqual(groupHintsByTask(original), expected)
+})
 
 test('transforms v0 to v1 schema', t => {
   const original = [{


### PR DESCRIPTION
Here's the actual implementations and the fixes discussed this am:
- transform array format of old hints.yaml into plain object
- group hints by Task