### PR TITLE
Rename tasks

### DIFF
--- a/simulation-scripts/scenario/container-ambush/tasks.yaml
+++ b/simulation-scripts/scenario/container-ambush/tasks.yaml
@@ -2,7 +2,7 @@ objective: Get postgres password.
 starting-point: kubectl pod exec.
 kind: 'cp.simulator/scenario:1.0.0'
 tasks:
-  Task 1:
+  '1':
     sort-order: 1
     hints:
       - text: What mounts do we have?
@@ -11,8 +11,8 @@ tasks:
       - text: Pull env vars from local Docker inspect.
       - text: Postgres containers' password as env var.
     starting-point: ''
-  Task 2:
+  '2':
     sort-order: 2
     hints:
-      - text: 'How did you access the password? Can you inject a secret another way?'
+      - text: How did you access the password? Can you inject a secret another way?
     starting-point: ''

--- a/simulation-scripts/scenario/container-defeat-in-detail/tasks.yaml
+++ b/simulation-scripts/scenario/container-defeat-in-detail/tasks.yaml
@@ -2,7 +2,7 @@ objective: Exec into a container on master with certificates mounted in to explo
 starting-point: kubectl access to the cluster.
 kind: 'cp.simulator/scenario:1.0.0'
 tasks:
-  Task 1:
+  '1':
     sort-order: 1
     hints:
       - text: I should choose which cert-manager pod to start in carefully.
@@ -15,7 +15,7 @@ tasks:
           etcd cluster earlier.
       - text: The key I'm after is probably the '/super/secret one'.
     starting-point: ''
-  Task 2:
+  '2':
     sort-order: 2
     hints:
       - text: Let's check the node config.

--- a/simulation-scripts/scenario/container-phalanx-formation/tasks.yaml
+++ b/simulation-scripts/scenario/container-phalanx-formation/tasks.yaml
@@ -2,7 +2,7 @@ objective: Find a secret in a log file.
 starting-point: Kubectl access outside the cluster.
 kind: 'cp.simulator/scenario:1.0.0'
 tasks:
-  Task 1:
+  '1':
     sort-order: 1
     hints:
       - text: So I need to start in the container-phalanx-formation namespace.

--- a/simulation-scripts/scenario/etcd-inverted-wedge/tasks.yaml
+++ b/simulation-scripts/scenario/etcd-inverted-wedge/tasks.yaml
@@ -4,7 +4,7 @@ objective: >-
 starting-point: pod in cluster
 kind: 'cp.simulator/scenario:1.0.0'
 tasks:
-  Task 1:
+  '1':
     sort-order: 1
     hints:
       - text: >-
@@ -20,7 +20,7 @@ tasks:
           --insecure-transport=false --insecure-skip-tls-verify get
           /registry/secrets/default/credentials
     starting-point: ''
-  Task 2:
+  '2':
     sort-order: 2
     hints:
       - text: How could we reach the etcd backend with no certificates?

--- a/simulation-scripts/scenario/master-bait-and-bleed/tasks.yaml
+++ b/simulation-scripts/scenario/master-bait-and-bleed/tasks.yaml
@@ -2,7 +2,7 @@ objective: API is enabled on --insecure-bind-address and --insecure-port
 starting-point: pod in cluster
 kind: 'cp.simulator/scenario:1.0.0'
 tasks:
-  Task 1:
+  '1':
     sort-order: 1
     hints:
       - text: >-
@@ -12,7 +12,7 @@ tasks:
           Looks like you may be able to access the Kubernetes API on port 8080.
           Try curling some of the end-points. You may need to download curl.
     starting-point: ''
-  Task 2:
+  '2':
     sort-order: 2
     hints:
       - text: >-

--- a/simulation-scripts/scenario/master-encirclement/tasks.yaml
+++ b/simulation-scripts/scenario/master-encirclement/tasks.yaml
@@ -2,7 +2,7 @@ objective: Enable MutatingAdmissionWebhook admission controller in the API serve
 starting-point: On the master node.
 kind: 'cp.simulator/scenario:1.0.0'
 tasks:
-  Task 1:
+  '1':
     sort-order: 1
     hints:
       - text: >-

--- a/simulation-scripts/scenario/network-feint/tasks.yaml
+++ b/simulation-scripts/scenario/network-feint/tasks.yaml
@@ -2,7 +2,7 @@ objective: Use misconfigured svc to compromise db.
 starting-point: Outside the cluster.
 kind: 'cp.simulator/scenario:1.0.0'
 tasks:
-  Task 1:
+  '1':
     sort-order: 1
     hints:
       - text: What's returning the empty responses when the NodePort is queried?
@@ -13,13 +13,13 @@ tasks:
           password, could this be it?
       - text: 'Hmm, how do I list tables and view the keys in tables again?'
     starting-point: ''
-  Task 2:
+  '2':
     sort-order: 2
     hints:
       - text: The database shouldn't be talking to the outside world.
       - text: The labels on this service are interesting.
     starting-point: ''
-  Task 3:
+  '3':
     sort-order: 3
     hints:
       - text: I wonder if a network policy would help here.

--- a/simulation-scripts/scenario/network-hammer-and-anvil/tasks.yaml
+++ b/simulation-scripts/scenario/network-hammer-and-anvil/tasks.yaml
@@ -2,7 +2,7 @@ objective: Use badly configured database to exfiltrate data.
 starting-point: Inside a frontend pod.
 kind: 'cp.simulator/scenario:1.0.0'
 tasks:
-  Task 1:
+  '1':
     sort-order: 1
     hints:
       - text: Is there anything useful in the env vars?
@@ -15,7 +15,7 @@ tasks:
           I have an IP and SSH key from the welcome text to this challenge, I
           can 'scp' my data to there.
     starting-point: ''
-  Task 2:
+  '2':
     sort-order: 2
     hints:
       - text: The database shouldn't need to talk externally.

--- a/simulation-scripts/scenario/network-hedgehog-defence/tasks.yaml
+++ b/simulation-scripts/scenario/network-hedgehog-defence/tasks.yaml
@@ -2,7 +2,7 @@ objective: Compromised database from outside namespace.
 starting-point: Inside setup pod.
 kind: 'cp.simulator/scenario:1.0.0'
 tasks:
-  Task 1:
+  '1':
     sort-order: 1
     hints:
       - text: Is it possible to hit the database service from the setup pod?
@@ -14,9 +14,10 @@ tasks:
           Do Postgres databases have passwords by default? I wonder what the
           default username for the SQL database is.
       - text: 'Hmm, how do I list tables and view the keys in tables again?'
-      - text: To query db from setupd pod ```psql -h database.network-hedgehog-defence -U postgres```
+      - text: >-
+          To query db from setupd pod ```psql -h database.network-hedgehog-defence -U postgres```
     starting-point: ''
-  Task 2:
+  '2':
     sort-order: 2
     hints:
       - text: >-

--- a/simulation-scripts/scenario/network-swarming/tasks.yaml
+++ b/simulation-scripts/scenario/network-swarming/tasks.yaml
@@ -2,7 +2,7 @@ objective: Use misconfigured svc to compromise db.
 starting-point: Inside a frontend pod.
 kind: 'cp.simulator/scenario:1.0.0'
 tasks:
-  Task 1:
+  '1':
     sort-order: 1
     hints:
       - text: >-
@@ -18,7 +18,7 @@ tasks:
           password, could this be it?
       - text: 'Hmm, how do I list tables and view the keys in tables again?'
     starting-point: ''
-  Task 2:
+  '2':
     sort-order: 2
     hints:
       - text: The database shouldn't be talking to the frontend.

--- a/simulation-scripts/scenario/node-amphibious-operations/tasks.yaml
+++ b/simulation-scripts/scenario/node-amphibious-operations/tasks.yaml
@@ -2,21 +2,27 @@ objective: Node compromise to get unauth kubelet API access.
 starting-point: Pod 'start-pod' in cluster
 kind: 'cp.simulator/scenario:1.0.0'
 tasks:
-  Task 1:
+  '1':
     sort-order: 1
     hints:
       - text: Have you looked into the the kubelet?
-      - text: The kubelet read-write API sits on port 10250. You may need to install some tools to get the information you need.
       - text: >-
-          Get the pod information from one of the nodes until you hit a good pod; curl -k https://<node-IP>:10250/pods
-          What can you do with this information?
+          The kubelet read-write API sits on port 10250. You may need to install
+          some tools to get the information you need.
       - text: >-
-          From the pod information you saw that there are some secrets mounted in the secret-pod. Can you run any commands in the pod?
+          Get the pod information from one of the nodes until you hit a good
+          pod; curl -k https://<node-IP>:10250/pods What can you do with this
+          information?
       - text: >-
-          Run the printenv command in the container you found; curl -k -XPOST "https://<node-ip>:10250/run/node-amphibious-operations/<pod name>/<container name>" -d "cmd=printenv"
-          You will be able to find the pod and container name from the previous pods endpoint.
+          From the pod information you saw that there are some secrets mounted
+          in the secret-pod. Can you run any commands in the pod?
+      - text: >-
+          Run the printenv command in the container you found; curl -k -XPOST
+          "https://<node-ip>:10250/run/node-amphibious-operations/<pod
+          name>/<container name>" -d "cmd=printenv" You will be able to find the
+          pod and container name from the previous pods endpoint.
     starting-point: ''
-  Task 2:
+  '2':
     sort-order: 2
     hints:
       - text: You need to fix /var/lib/kubelet/config.yaml.

--- a/simulation-scripts/scenario/node-raiding/tasks.yaml
+++ b/simulation-scripts/scenario/node-raiding/tasks.yaml
@@ -2,7 +2,7 @@ objective: Node compromise to get readonly kubelet API access.
 starting-point: SSH node - any worker.
 kind: 'cp.simulator/scenario:1.0.0'
 tasks:
-  Task 1:
+  '1':
     sort-order: 1
     hints:
       - text: Have you looked into the the kubelet?
@@ -11,12 +11,11 @@ tasks:
           Get anything directly from the kubelet API, circumventing the
           Kubernetes server API, e.g. curl http://<node-IP>:10255/pods
     starting-point: ''
-  Task 2:
+  '2':
     sort-order: 2
     hints:
       - text: You need to fix /var/lib/kubelet/config.yaml.
-      - text: >-
-          readOnly port should be 0.
+      - text: readOnly port should be 0.
       - text: >-
           'systemctl daemon-reload; systemctl restart kubelet.service' applies
           the config changes.

--- a/simulation-scripts/scenario/node-shock-tactics/tasks.yaml
+++ b/simulation-scripts/scenario/node-shock-tactics/tasks.yaml
@@ -2,7 +2,7 @@ objective: Node escalation to workload compromise.
 starting-point: SSH node-any non-root.
 kind: 'cp.simulator/scenario:1.0.0'
 tasks:
-  Task 1:
+  '1':
     sort-order: 1
     hints:
       - text: How would you escalate yourself on this node?
@@ -13,7 +13,7 @@ tasks:
       - text: Set root password for host.
       - text: Login as root.
     starting-point: ''
-  Task 2:
+  '2':
     sort-order: 2
     hints:
       - text: '''df -h'' as host root to see tmpfs mounts.'

--- a/simulation-scripts/scenario/policy-echelon-formation/tasks.yaml
+++ b/simulation-scripts/scenario/policy-echelon-formation/tasks.yaml
@@ -2,7 +2,7 @@ objective: Use privileged container to get host secrets.
 starting-point: Inside the Process Monitor container.
 kind: 'cp.simulator/scenario:1.0.0'
 tasks:
-  Task 1:
+  '1':
     sort-order: 1
     hints:
       - text: >-
@@ -16,12 +16,12 @@ tasks:
       - text: What's in /proc/<pid>/root?
       - text: The final secrets I need are in /proc/<pid>/root/secrets.
     starting-point: ''
-  Task 2:
+  '2':
     sort-order: 2
     hints:
       - text: Looks like I need to  stop adding ALL capabilities to the pod.
     starting-point: ''
-  Task 3:
+  '3':
     sort-order: 3
     hints:
       - text: I think a PodSecurityPolicy might be useful here.

--- a/simulation-scripts/scenario/policy-fire-support/tasks.yaml
+++ b/simulation-scripts/scenario/policy-fire-support/tasks.yaml
@@ -2,14 +2,14 @@ objective: Use Sudo to get un readable ssh keys from a host mount.
 starting-point: Inside Jenkins container.
 kind: 'cp.simulator/scenario:1.0.0'
 tasks:
-  Task 1:
+  '1':
     sort-order: 1
     hints:
       - text: I should look around and see if I can find those key.
       - text: Hmm I can't seem to open /root-ssh.
       - text: Is sudo installed in this container?
     starting-point: ''
-  Task 2:
+  '2':
     sort-order: 2
     hints:
       - text: I wonder if there is a PodSecurityPolicy on this deployment.

--- a/simulation-scripts/scenario/policy-force-dispersal/tasks.yaml
+++ b/simulation-scripts/scenario/policy-force-dispersal/tasks.yaml
@@ -2,7 +2,7 @@ objective: Enable PodSecurityPolicy in the API server.
 starting-point: On the master node.
 kind: 'cp.simulator/scenario:1.0.0'
 tasks:
-  Task 1:
+  '1':
     sort-order: 1
     hints:
       - text: >-

--- a/simulation-scripts/scenario/policy-vertical-envelopment/tasks.yaml
+++ b/simulation-scripts/scenario/policy-vertical-envelopment/tasks.yaml
@@ -2,7 +2,7 @@ objective: Use privileged container to get host secrets.
 starting-point: Inside Jenkins container.
 kind: 'cp.simulator/scenario:1.0.0'
 tasks:
-  Task 1:
+  '1':
     sort-order: 1
     hints:
       - text: What mounts do I have in this container.
@@ -12,12 +12,12 @@ tasks:
       - text: Looks like the xvda1 is the host disk.
       - text: The secret I need is in the node-secret directory.
     starting-point: ''
-  Task 2:
+  '2':
     sort-order: 2
     hints:
       - text: Looks like I need to set privileged to false.
     starting-point: ''
-  Task 3:
+  '3':
     sort-order: 3
     hints:
       - text: I think a PodSecurityPolicy might be useful here.

--- a/simulation-scripts/scenario/rbac-contact-drill/tasks.yaml
+++ b/simulation-scripts/scenario/rbac-contact-drill/tasks.yaml
@@ -4,14 +4,14 @@ objective: >-
 starting-point: ubuntu pod
 kind: 'cp.simulator/scenario:1.0.0'
 tasks:
-  Task 1:
+  '1':
     sort-order: 1
     hints:
       - text: >-
           Can you hit the API from inside the pod? You may need to install curl
           and kubectl.
     starting-point: ''
-  Task 2:
+  '2':
     sort-order: 2
     hints:
       - text: >-

--- a/simulation-scripts/scenario/rbac-flanking-maneuver/tasks.yaml
+++ b/simulation-scripts/scenario/rbac-flanking-maneuver/tasks.yaml
@@ -1,28 +1,33 @@
-objective: SSH into vulnerable workload, wget secrets using permissive SA.
+objective: 'SSH into vulnerable workload, wget secrets using permissive SA.'
 starting-point: none
 kind: 'cp.simulator/scenario:1.0.0'
 tasks:
-  Task 1:
+  '1':
     sort-order: 1
     hints:
-      - text: Find open SSH port in workload. You can use nmap. Remember it runs on a nodeport.
+      - text: >-
+          Find open SSH port in workload. You can use nmap. Remember it runs on
+          a nodeport.
       - text: The open nodeport was 30022. Brute force host SSH default password.
       - text: Username is admin and password is password.
       - text: Look around for credentials and tools. Can you hit the API?
-      - text: Use wget to hit the api at default port 6443. The service account token looks like it can schedule workloads and get secrets.
+      - text: >-
+          Use wget to hit the api at default port 6443. The service account
+          token looks like it can schedule workloads and get secrets.
     starting-point: ''
-  Task 2:
+  '2':
     sort-order: 2
     hints:
-      - text: >-
-          What identity is assigned the pod?
+      - text: What identity is assigned the pod?
       - text: Have a look at the roles and rolebindings.
       - text: >-
-          Since the pod doesn't need to talk to the API, you can just delete the rolebinding.
+          Since the pod doesn't need to talk to the API, you can just delete the
+          rolebinding.
     starting-point: ''
-  Task 3:
+  '3':
     sort-order: 3
     hints:
       - text: >-
-          Don't use passwords for ssh connections, and definitely not easy ones. 
+          Don't use passwords for ssh connections, and definitely not easy
+          ones. 
     starting-point: ''

--- a/simulation-scripts/scenario/rbac-sangar/tasks.yaml
+++ b/simulation-scripts/scenario/rbac-sangar/tasks.yaml
@@ -4,7 +4,7 @@ objective: >-
 starting-point: frontend pod in the rbac-sangar namespace
 kind: 'cp.simulator/scenario:1.0.0'
 tasks:
-  Task 1:
+  '1':
     sort-order: 1
     hints:
       - text: Can I run or install kubectl in here?
@@ -12,7 +12,7 @@ tasks:
           Hmm, I can't see secrets directly. I wonder what the deployment of the
           application pods looks like?
     starting-point: ''
-  Task 2:
+  '2':
     sort-order: 2
     hints:
       - text: >-
@@ -26,7 +26,7 @@ tasks:
           Looks like the authenticated-view ClusterRoleBinding is giving the
           group more permissions! It should probably be deleted for now.
     starting-point: ''
-  Task 3:
+  '3':
     sort-order: 3
     hints:
       - text: The pod should not mount the default service token.
@@ -35,7 +35,7 @@ tasks:
           inspiration.
       - text: I need to set automountServiceAccountToken to be false
     starting-point: ''
-  Task 4:
+  '4':
     sort-order: 4
     hints:
       - text: I need to replace the environment variable with a secret.

--- a/simulation-scripts/scenario/rbac-shoot-and-scoot/tasks.yaml
+++ b/simulation-scripts/scenario/rbac-shoot-and-scoot/tasks.yaml
@@ -4,14 +4,14 @@ objective: >-
 starting-point: pod
 kind: 'cp.simulator/scenario:1.0.0'
 tasks:
-  Task 1:
+  '1':
     sort-order: 1
     hints:
       - text: >-
           Can you hit the API from inside the pod? What is the DNS resolvable
           name?
     starting-point: ''
-  Task 2:
+  '2':
     sort-order: 2
     hints:
       - text: What user is assigned when hitting the API with no identity?

--- a/simulation-scripts/scenario/secret-high-ground/tasks.yaml
+++ b/simulation-scripts/scenario/secret-high-ground/tasks.yaml
@@ -2,7 +2,7 @@ objective: Fix a pull policy and then add a secret to the pod.
 starting-point: Cluster Access
 kind: 'cp.simulator/scenario:1.0.0'
 tasks:
-  Task 1:
+  '1':
     sort-order: 1
     hints:
       - text: I should probably check the deployment.
@@ -11,7 +11,7 @@ tasks:
           the offical repository?
       - text: I should set the PullPolicy flag to Always.
     starting-point: ''
-  Task 2:
+  '2':
     sort-order: 2
     hints:
       - text: A kubernetes secret is the best choice here.

--- a/simulation-scripts/scenario/secret-tank-desant/tasks.yaml
+++ b/simulation-scripts/scenario/secret-tank-desant/tasks.yaml
@@ -2,7 +2,7 @@ objective: Compromise secret from running workload.
 starting-point: kubectl pod exec.
 kind: 'cp.simulator/scenario:1.0.0'
 tasks:
-  Task 1:
+  '1':
     sort-order: 1
     hints:
       - text: kubectl exec into workload.

--- a/tools/scenario-tools/lib/args.js
+++ b/tools/scenario-tools/lib/args.js
@@ -17,6 +17,10 @@ function parse (argv) {
 
   if (command === 'migrate') {
     const migrateArguments = [{
+      name: 'type',
+      alias: 't',
+      type: String
+    }, {
       name: 'name',
       alias: 'n',
       type: String
@@ -32,6 +36,10 @@ function parse (argv) {
       stopAtFirstUnknown: true,
       argv: remaining
     })
+
+    if (!options.type) {
+      throw createArgumentError('You must supply the type of migration to perform')
+    }
 
     if (!options.all && !options.name) {
       throw createArgumentError('You must supply one of --all or --name arguments')

--- a/tools/scenario-tools/lib/io.js
+++ b/tools/scenario-tools/lib/io.js
@@ -43,12 +43,12 @@ function writeYamlFile (hints, p) {
 
 // Given a relative path to a scenario directory, scans for scenarios
 // Returns a list of absolute paths to all `hints.yaml` files
-function findScenarioHintsFiles (scenariosDir) {
+function findScenarioFiles (scenariosDir, filename) {
   const absPath = resolve(scenariosDir)
 
   return readdirSync(absPath, { withFileTypes: true })
     .filter(dirent => dirent.isDirectory())
-    .map(dirent => join(absPath, dirent.name, 'hints.yaml'))
+    .map(dirent => join(absPath, dirent.name, filename))
 }
 
 module.exports = {
@@ -56,5 +56,5 @@ module.exports = {
   saveProgress,
   loadYamlFile,
   writeYamlFile,
-  findScenarioHintsFiles
+  findScenarioFiles
 }

--- a/tools/scenario-tools/lib/migrate.js
+++ b/tools/scenario-tools/lib/migrate.js
@@ -1,4 +1,15 @@
-const { loadYamlFile, writeYamlFile, findScenarioHintsFiles } = require('./io')
+const { loadYamlFile, writeYamlFile, findScenarioFiles } = require('./io')
+const { createLogger } = require('./logger')
+
+const logger = createLogger({})
+
+// A transformation function accepts a tasks manifest as a JS object and
+// returns a transformed manifest.  A transformation function *must* include
+// a check to validate that the manifest is in the format expected before making
+// any changes and warn and short circuit if not
+
+// These transformations are a history of the migrations we have performed over
+// time on the tasks.yaml files
 
 function groupHintsByTask (hints) {
   return hints.reduce((acc, hint) => {
@@ -26,6 +37,10 @@ function groupHintsByTask (hints) {
 // Takes an array of top level yaml properties represented as a JS object and
 // Returns a transformed array of top-level properties in the new format
 function transformV0ToV1 (hints) {
+  if (!Array.isArray(hints)) {
+    return logger.warn('skipping manifest because it was not an array')
+  }
+
   const transformed = {}
   // remove hint count
   delete hints[0].general_overview['num-hints']
@@ -48,17 +63,55 @@ function transformV0ToV1 (hints) {
   return transformed
 }
 
-function migrate () {
-  const hintsFiles = findScenarioHintsFiles('./simulation-scripts/scenario')
-  hintsFiles.forEach(hintsFile => {
-    const original = loadYamlFile(hintsFile)
-    const transformed = transformV0ToV1(original)
-    writeYamlFile(transformed, hintsFile)
+// Renames tasks from e.g. 'Task 1' -> '1'
+function removeTaskPrefix (manifest) {
+  const tasks = manifest.tasks
+
+  const unrecognised = Object.keys(tasks).filter(task => !task.startsWith('Task '))
+
+  if (unrecognised.length > 0) {
+    return logger.warn('skipping manifest due to unrecognised tasks')
+  }
+
+  Object.keys(tasks).forEach(key => {
+    // new name is just the digit at the end of the string
+    const newname = key[key.length - 1]
+
+    Object.defineProperty(tasks, newname, Object.getOwnPropertyDescriptor(tasks, key))
+    delete tasks[key]
+  })
+
+  return manifest
+}
+
+function migrate (options) {
+  // TODO(rem): check options and migrate a single scenario or all
+
+  let manifests
+  if (options.type === 'legacy') {
+    manifests = findScenarioFiles('./simulation-scripts/scenario', 'hints.yaml')
+  } else {
+    manifests = findScenarioFiles('./simulation-scripts/scenario', 'tasks.yaml')
+  }
+
+  manifests.forEach(manifest => {
+    const original = loadYamlFile(manifest)
+    let transformed
+    if (options.type === 'legacy') {
+      transformed = transformV0ToV1(original)
+    } else if (options.type === 'remove-task-prefix') {
+      transformed = removeTaskPrefix(original)
+    } else {
+      throw new Error('unrecognised type of migration')
+    }
+
+    writeYamlFile(transformed, manifest)
   })
 }
 
 module.exports = {
   groupHintsByTask,
   transformV0ToV1,
+  removeTaskPrefix,
   migrate
 }

--- a/tools/scenario-tools/test/args_test.js
+++ b/tools/scenario-tools/test/args_test.js
@@ -2,23 +2,29 @@ const test = require('ava')
 const { parse, showUsage } = require('../lib/args')
 
 test('parse migrate with name option', t => {
-  const args = ['migrate', '--name', 'container-ambush']
+  const args = ['migrate', '--name', 'container-ambush', '--type', 'legacy']
   const parsed = parse(args)
 
   t.deepEqual({
     command: 'migrate',
     options: {
       name: 'container-ambush',
-      all: false
+      all: false,
+      type: 'legacy'
     }
   }, parsed)
 })
 
+test('parse migrate throws for missing type', t => {
+  const args = ['migrate', '--name', 'container-ambush']
+  t.throws(() => parse(args))
+})
+
 test('parse migrate with all option', t => {
-  const args = ['migrate', '--all']
+  const args = ['migrate', '--all', '--type', 'legacy']
   const parsed = parse(args)
 
-  t.deepEqual({ command: 'migrate', options: { all: true } }, parsed)
+  t.deepEqual({ command: 'migrate', options: { all: true, type: 'legacy' } }, parsed)
 })
 
 test('showUsage', t => {

--- a/tools/scenario-tools/test/migrate_test.js
+++ b/tools/scenario-tools/test/migrate_test.js
@@ -1,5 +1,5 @@
 const test = require('ava')
-const { transformV0ToV1, groupHintsByTask } = require('../lib/migrate')
+const { transformV0ToV1, removeTaskPrefix, groupHintsByTask } = require('../lib/migrate')
 
 test('groupHintsByTask', t => {
   const original = [
@@ -53,4 +53,46 @@ test('transforms v0 to v1 schema', t => {
   }
 
   t.deepEqual(expected, transformV0ToV1(original))
+})
+
+test('remove task prefix removes the prefixes', t => {
+  const original = {
+    kind: 'cp.simulator/scenario:1.0.0',
+    objective: 'test objective',
+    'starting-point': 'kubectl pod exec.',
+    tasks: {
+      'Task 1': {
+        'sort-order': 1,
+        'starting-point': '',
+        hints: [{ text: 'test hint 1' }, { text: 'test hint 2' }]
+      },
+      'Task 2': {
+        'sort-order': 1,
+        'starting-point': '',
+        hints: [{ text: 'test hint 1' }, { text: 'test hint 2' }]
+      }
+
+    }
+  }
+
+  const expected = {
+    kind: 'cp.simulator/scenario:1.0.0',
+    objective: 'test objective',
+    'starting-point': 'kubectl pod exec.',
+    tasks: {
+      '1': { // eslint-disable-line
+        'sort-order': 1,
+        'starting-point': '',
+        hints: [{ text: 'test hint 1' }, { text: 'test hint 2' }]
+      },
+      '2': { // eslint-disable-line
+        'sort-order': 1,
+        'starting-point': '',
+        hints: [{ text: 'test hint 1' }, { text: 'test hint 2' }]
+      }
+
+    }
+  }
+
+  t.deepEqual(expected, removeTaskPrefix(original))
 })


### PR DESCRIPTION
This adds a migration script to rename all the tasks en masse removing the "Task " prefix.  And then renames them all.  The migration tool serializes and deserializes the yaml so its worth paying attention to any reformatting - I glanced through and fixed up one case manually where it added a linebreak inside a backtick quoted string

**Please note my earlier pull request to update the hints UI should be reviewed and merged by abdullah first before merging this** as this builds on top of that work.

Most of the commits you see here are also in the earlier PR - only the last 2 are relevant:

- feat(tools): add migration for removing task prefixes
- refactor(scenarios): remove 'Task' from all task names
