### PR TITLE
Attack container tag selection

### DIFF
--- a/cmd/infra.go
+++ b/cmd/infra.go
@@ -22,13 +22,14 @@ func newCreateCommand(logger *zap.SugaredLogger) *cobra.Command {
 			}
 
 			scenariosDir := viper.GetString("scenarios-dir")
+			attackTag := viper.GetString("attack-container-tag")
 			tfDir := viper.GetString("tf-dir")
-			err := simulator.Create(logger, tfDir, bucket)
+			err := simulator.Create(logger, tfDir, bucket, attackTag)
 			if err != nil {
 				logger.Errorw("Error creating infrastructure", zap.Error(err))
 			}
 
-			cfg, err := simulator.Config(logger, tfDir, scenariosDir, bucket)
+			cfg, err := simulator.Config(logger, tfDir, scenariosDir, bucket, attackTag)
 			if err != nil {
 				return errors.Wrap(err, "Error getting SSH config")
 			}
@@ -57,7 +58,8 @@ func newStatusCommand(logger *zap.SugaredLogger) *cobra.Command {
 				return nil
 			}
 			tfDir := viper.GetString("tf-dir")
-			tfo, err := simulator.Status(logger, tfDir, bucket)
+			attackTag := viper.GetString("attack-container-tag")
+			tfo, err := simulator.Status(logger, tfDir, bucket, attackTag)
 			if err != nil {
 				logger.Errorw("Error getting status of infrastructure", zap.Error(err))
 				return err
@@ -91,7 +93,8 @@ func newDestroyCommand(logger *zap.SugaredLogger) *cobra.Command {
 			}
 			tfDir := viper.GetString("tf-dir")
 
-			err := simulator.Destroy(logger, tfDir, bucket)
+			attackTag := viper.GetString("attack-container-tag")
+			err := simulator.Destroy(logger, tfDir, bucket, attackTag)
 			if err != nil {
 				logger.Errorw("Error destroying infrastructure", zap.Error(err))
 			}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -46,6 +46,10 @@ func newCmdRoot() *cobra.Command {
 		"Path to a directory containing the infrastructure scripts")
 	viper.BindPFlag("tf-dir", rootCmd.PersistentFlags().Lookup("tf-dir"))
 
+	rootCmd.PersistentFlags().StringP("attack-container-tag", "a", "latest",
+		"The attack container tag to pull on the bastion")
+	viper.BindPFlag("attack-container-tag", rootCmd.PersistentFlags().Lookup("attack-container-tag"))
+
 	// TODO: (rem) this is also used to locate the perturb.sh script which may be
 	// subsumed by this app
 	rootCmd.PersistentFlags().StringP("scenarios-dir", "s", "./simulation-scripts",

--- a/cmd/scenario.go
+++ b/cmd/scenario.go
@@ -43,9 +43,10 @@ func newScenarioLaunchCommand(logger *zap.SugaredLogger) *cobra.Command {
 			bucket := viper.GetString("state-bucket")
 			tfDir := viper.GetString("tf-dir")
 			scenariosDir := viper.GetString("scenarios-dir")
+			attackTag := viper.GetString("attack-container-tag")
 			scenarioID := args[0]
 
-			if err := simulator.Launch(logger, tfDir, scenariosDir, bucket, scenarioID); err != nil {
+			if err := simulator.Launch(logger, tfDir, scenariosDir, bucket, scenarioID, attackTag); err != nil {
 				if strings.HasPrefix(err.Error(), "Scenario not found") {
 					logger.Warn(err.Error())
 					return nil

--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -17,7 +17,8 @@ func newSSHConfigCommand(logger *zap.SugaredLogger) *cobra.Command {
 			scenariosDir := viper.GetString("scenarios-dir")
 			bucket := viper.GetString("state-bucket")
 			tfDir := viper.GetString("tf-dir")
-			cfg, err := simulator.Config(logger, tfDir, scenariosDir, bucket)
+			attackTag := viper.GetString("attack-container-tag")
+			cfg, err := simulator.Config(logger, tfDir, scenariosDir, bucket, attackTag)
 			if err != nil {
 				return errors.Wrap(err, "Error getting SSH config")
 			}
@@ -51,8 +52,9 @@ func newSSHAttackCommand(logger *zap.SugaredLogger) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			bucket := viper.GetString("state-bucket")
 			tfDir := viper.GetString("tf-dir")
+			attackTag := viper.GetString("attack-container-tag")
 
-			return simulator.Attack(logger, tfDir, bucket)
+			return simulator.Attack(logger, tfDir, bucket, attackTag)
 		},
 	}
 

--- a/pkg/simulator/launch.go
+++ b/pkg/simulator/launch.go
@@ -10,7 +10,7 @@ import (
 // Launch runs perturb.sh to setup a scenario with the supplied `id` assuming
 // the infrastructure has been created.  Returns an error if the infrastructure
 // is not ready or something goes wrong
-func Launch(logger *zap.SugaredLogger, tfDir, scenariosDir, bucketName, id string) error {
+func Launch(logger *zap.SugaredLogger, tfDir, scenariosDir, bucketName, id, attackTag string) error {
 	logger.Debugf("Loading scenario manifest from %s", scenariosDir)
 	manifest, err := scenario.LoadManifest(scenariosDir)
 	if err != nil {
@@ -23,7 +23,7 @@ func Launch(logger *zap.SugaredLogger, tfDir, scenariosDir, bucketName, id strin
 	}
 
 	logger.Debugf("Checking status of infrastructure")
-	tfo, err := Status(logger, tfDir, bucketName)
+	tfo, err := Status(logger, tfDir, bucketName, attackTag)
 	if !tfo.IsUsable() {
 		return errors.Errorf("No infrastructure, please run simulator infra create")
 	}

--- a/pkg/simulator/ssh.go
+++ b/pkg/simulator/ssh.go
@@ -9,8 +9,8 @@ import (
 // Config returns a pointer to string containing the stanzas to add to an ssh
 // config file so that the kubernetes nodes are connectable directly via the
 // bastion or an error if the infrastructure has not been created
-func Config(logger *zap.SugaredLogger, tfDir, scenarioPath, bucketName string) (*string, error) {
-	tfo, err := Status(logger, tfDir, bucketName)
+func Config(logger *zap.SugaredLogger, tfDir, scenarioPath, bucketName, attackTag string) (*string, error) {
+	tfo, err := Status(logger, tfDir, bucketName, attackTag)
 	if err != nil {
 		return nil, errors.Wrap(err, "Error getting infrastructure status")
 	}
@@ -24,9 +24,9 @@ func Config(logger *zap.SugaredLogger, tfDir, scenarioPath, bucketName string) (
 
 // Attack establishes an SSH connection to the attack container running on the
 // bastion host ready for the user to attempt to complete a scenario
-func Attack(logger *zap.SugaredLogger, tfDir, bucketName string) error {
+func Attack(logger *zap.SugaredLogger, tfDir, bucketName, attackTag string) error {
 	logger.Debugf("Checking status of infrastructure")
-	tfo, err := Status(logger, tfDir, bucketName)
+	tfo, err := Status(logger, tfDir, bucketName, attackTag)
 	if err != nil {
 		return errors.Wrap(err, "Error getting infrastrucutre status")
 	}

--- a/pkg/simulator/ssh_test.go
+++ b/pkg/simulator/ssh_test.go
@@ -9,7 +9,7 @@ import (
 func Test_Config(t *testing.T) {
 	t.Skip("Need to mock out terraform output")
 	t.Parallel()
-	cfg, err := simulator.Config(noopLogger, fixture("noop-tf-dir"), fixture("valid"), "test")
+	cfg, err := simulator.Config(noopLogger, fixture("noop-tf-dir"), fixture("valid"), "test", "latest")
 
 	assert.Nil(t, err)
 	assert.NotNil(t, cfg)

--- a/pkg/simulator/terraform_test.go
+++ b/pkg/simulator/terraform_test.go
@@ -30,20 +30,20 @@ func Test_PrepareTfArgs(t *testing.T) {
 }
 
 func Test_Status(t *testing.T) {
-	tfo, err := simulator.Status(noopLogger, fixture("noop-tf-dir"), "test")
+	tfo, err := simulator.Status(noopLogger, fixture("noop-tf-dir"), "test", "latest")
 
 	assert.Nil(t, err, "Got an error")
 	assert.NotNil(t, tfo, "Got no terraform output")
 }
 
 func Test_Create(t *testing.T) {
-	err := simulator.Create(noopLogger, fixture("noop-tf-dir"), "test")
+	err := simulator.Create(noopLogger, fixture("noop-tf-dir"), "test", "latest")
 
 	assert.Nil(t, err)
 }
 
 func Test_Destroy(t *testing.T) {
-	err := simulator.Destroy(noopLogger, fixture("noop-tf-dir"), "test")
+	err := simulator.Destroy(noopLogger, fixture("noop-tf-dir"), "test", "test")
 
 	assert.Nil(t, err)
 }

--- a/pkg/simulator/terraform_vars.go
+++ b/pkg/simulator/terraform_vars.go
@@ -15,14 +15,16 @@ type TfVars struct {
 	PublicKey  string
 	AccessCIDR string
 	BucketName string
+	AttackTag  string
 }
 
 // NewTfVars creates a TfVars struct with all the defaults
-func NewTfVars(publicKey, accessCIDR, bucketName string) TfVars {
+func NewTfVars(publicKey, accessCIDR, bucketName, attackTag string) TfVars {
 	return TfVars{
 		PublicKey:  publicKey,
 		AccessCIDR: accessCIDR,
 		BucketName: bucketName,
+		AttackTag:  attackTag,
 	}
 }
 
@@ -50,13 +52,14 @@ func writeProvidersFile(tfDir, bucket string) error {
 }
 
 func (tfv *TfVars) String() string {
-	return "access_key = \"" + tfv.PublicKey + "\"\n" + "access_cidr = \"" + tfv.AccessCIDR + "\"\n"
+	return "access_key = \"" + tfv.PublicKey + "\"\n" + "access_cidr = \"" + tfv.AccessCIDR + "\"\n" + "attack_container_tag = \"" + tfv.AttackTag + "\"\n"
+
 }
 
 // EnsureLatestTfVarsFile writes an tfvars file if one hasnt already been made
-func EnsureLatestTfVarsFile(tfDir, publicKey, accessCIDR, bucket string) error {
+func EnsureLatestTfVarsFile(tfDir, publicKey, accessCIDR, bucket, attackTag string) error {
 	filename := tfDir + "/settings/bastion.tfvars"
-	tfv := NewTfVars(publicKey, accessCIDR, bucket)
+	tfv := NewTfVars(publicKey, accessCIDR, bucket, attackTag)
 
 	err := writeProvidersFile(tfDir, bucket)
 	if err != nil {

--- a/pkg/simulator/terraform_vars_test.go
+++ b/pkg/simulator/terraform_vars_test.go
@@ -9,9 +9,10 @@ import (
 
 func Test_TfVars_String(t *testing.T) {
 	t.Parallel()
-	tfv := simulator.NewTfVars("ssh-rsa", "10.0.0.1/16", "test")
+	tfv := simulator.NewTfVars("ssh-rsa", "10.0.0.1/16", "test", "latest")
 	expected := `access_key = "ssh-rsa"
 access_cidr = "10.0.0.1/16"
+attack_container_tag = "latest"
 `
 	assert.Equal(t, tfv.String(), expected)
 }
@@ -20,7 +21,7 @@ func Test_Ensure_TfVarsFile_with_settings(t *testing.T) {
 	tfDir := fixture("tf-dir-with-settings")
 	varsFile := tfDir + "/settings/bastion.tfVars"
 
-	err := simulator.EnsureLatestTfVarsFile(tfDir, "ssh-rsa", "10.0.0.1/16", "test")
+	err := simulator.EnsureLatestTfVarsFile(tfDir, "ssh-rsa", "10.0.0.1/16", "test", "latest")
 	assert.Nil(t, err, "Got an error")
 
 	assert.Equal(t, util.MustSlurp(varsFile), "test = true\n")

--- a/simulator.yaml
+++ b/simulator.yaml
@@ -1,3 +1,4 @@
 loglevel: debug
 scenarios-dir: /app/simulation-scripts/
 tf-dir: /app/terraform/deployments/AWS
+attack-container-tag: latest

--- a/terraform/deployments/AWS/main.tf
+++ b/terraform/deployments/AWS/main.tf
@@ -22,15 +22,16 @@ module "SshKey" {
 
 // Setup Bastion host
 module "Bastion" {
-  source              = "../../modules/AWS/Bastion"
-  ami_id              = "${module.Ami.AmiId}"
-  instance_type       = "${var.instance_type}"
-  access_key_name     = "${module.SshKey.KeyPairName}"
-  security_group      = "${module.SecurityGroups.BastionSecurityGroupID}"
-  subnet_id           = "${module.Networking.PublicSubnetId}"
-  master_ip_addresses = "${join(",", "${module.Kubernetes.K8sMasterPrivateIp}")}"
-  node_ip_addresses   = "${join(",", "${module.Kubernetes.K8sNodesPrivateIp}")}"
-  default_tags        = "${var.default_tags}"
+  source               = "../../modules/AWS/Bastion"
+  ami_id               = "${module.Ami.AmiId}"
+  instance_type        = "${var.instance_type}"
+  access_key_name      = "${module.SshKey.KeyPairName}"
+  security_group       = "${module.SecurityGroups.BastionSecurityGroupID}"
+  subnet_id            = "${module.Networking.PublicSubnetId}"
+  master_ip_addresses  = "${join(",", "${module.Kubernetes.K8sMasterPrivateIp}")}"
+  node_ip_addresses    = "${join(",", "${module.Kubernetes.K8sNodesPrivateIp}")}"
+  attack_container_tag = "${var.attack_container_tag}"
+  default_tags         = "${var.default_tags}"
 }
 
 // Setup Kubernetes master and nodes

--- a/terraform/deployments/AWS/terraform-bundle.hcl
+++ b/terraform/deployments/AWS/terraform-bundle.hcl
@@ -1,5 +1,5 @@
 terraform {
-  version = "0.12.11"
+  version = "0.12.12"
 }
 
 providers {

--- a/terraform/deployments/AWS/variables.tf
+++ b/terraform/deployments/AWS/variables.tf
@@ -61,6 +61,11 @@ variable "number_of_cluster_instances" {
   default     = "2"
 }
 
+variable "attack_container_tag" {
+  description = "the docker tag of the attack container to use"
+  default     = "latest"
+}
+
 variable "default_tags" {
   description = "Default tags for all resources"
   type        = "map"

--- a/terraform/modules/AWS/Bastion/cloud-config.tf
+++ b/terraform/modules/AWS/Bastion/cloud-config.tf
@@ -1,7 +1,8 @@
 data "template_file" "cloud_config" {
   template = "${file("${path.module}/cloud-config.yaml")}"
   vars = {
-    master_ip_addresses = "${var.master_ip_addresses}"
-    node_ip_addresses   = "${var.node_ip_addresses}"
+    master_ip_addresses  = "${var.master_ip_addresses}"
+    node_ip_addresses    = "${var.node_ip_addresses}"
+    attack_container_tag = "${var.attack_container_tag}"
   }
 }

--- a/terraform/modules/AWS/Bastion/cloud-config.yaml
+++ b/terraform/modules/AWS/Bastion/cloud-config.yaml
@@ -11,7 +11,7 @@ hostname: "bastion"
 runcmd:
   - 'systemctl daemon-reload'
   - 'systemctl restart docker'
-  - 'docker pull controlplane/simulator-attack:latest'
+  - 'docker pull controlplane/simulator-attack:${attack_container_tag}'
 
 write_files:
   - path: /etc/bash.bashrc
@@ -43,7 +43,7 @@ write_files:
     content: |
       export MASTER_IP_ADDRESSES=${master_ip_addresses}
       export NODE_IP_ADDRESSES=${node_ip_addresses}
-      sudo -E docker run -h attack -v /home/ubuntu/progress.json:/progress.json -v /home/ubuntu/tasks.yaml:/tasks.yaml -v /home/ubuntu/challenge.txt:/challenge.txt -e BASE64_SSH_KEY -e MASTER_IP_ADDRESSES -e NODE_IP_ADDRESSES -it controlplane/simulator-attack:latest
+      sudo -E docker run -h attack -v /home/ubuntu/progress.json:/progress.json -v /home/ubuntu/tasks.yaml:/tasks.yaml -v /home/ubuntu/challenge.txt:/challenge.txt -e BASE64_SSH_KEY -e MASTER_IP_ADDRESSES -e NODE_IP_ADDRESSES -it controlplane/simulator-attack:${attack_container_tag}
   - path: /home/ubuntu/progress.json
     permissions: '0666'
     content: "{}"

--- a/terraform/modules/AWS/Bastion/variables.tf
+++ b/terraform/modules/AWS/Bastion/variables.tf
@@ -33,3 +33,7 @@ variable "default_tags" {
   type        = "map"
 }
 
+variable "attack_container_tag" {
+  description = "the docker tag of the attack container to use"
+}
+

--- a/test/fixtures/noop-tf-dir/settings/bastion.tfvars
+++ b/test/fixtures/noop-tf-dir/settings/bastion.tfvars
@@ -1,2 +1,3 @@
 access_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDOdlZr+QS+EPQVpoHFzGP/5s3H2rA1oH/1Ee7c3NkNrX+Q/z3IwceG/416Q6h3kc5aZq3MxYy69XHeYyMa1z0e/589XLZt7Dow9rjcwtkq99aeGzbYumzQ8Dm/tj+W+fw7xJHNuqICkxZgesN9uORjF5T8/4r888UxTTBv2LzvFzMsnQTXwnEC6OPwbfSJEpYev4Lfo2bli+aML7VE3Ea4DTxUJR4Fq4XBC5g2543iSmLK6CJqzID2UsDNjFfINzHdNvNwE061FgdO3xLZDdZi1EqOIO26fMH+wIcG4PlDMkdTZsTTJVuI9RqqpwPba8R5+nbvwtU9LgoNTwky4EgZ simulator-key"
 access_cidr = "2a00:23c5:ec3f:fd00:9a2c:bcff:fe4b:7e40/32"
+attack_container_tag = "test"


### PR DESCRIPTION
This pull request makes it possible to test tags other than "latest" of the attack container.  This means we will be able to make changes to the attack container and infra in a feature branch and work on the branch until completely happy before merging.  The new workflow to make changes to the attack container on a branch will be:

* code
* commit changes on branch
* `cd attack && CONTAINER_TAG=super-cool-feature make docker-push` to push the tagged attack container
* `cd .. && make run` to run the launch container
* `simulator infra create --attack-container-tag=super-cool-feature`

**Implementation notes**

This pull request adds a new tf var called "attack_container_tag".  The var is threaded through from the deployment to the bastion and is then templated into the cloud-config to pull the appropriate tag and launch that tag when the
ubuntu user logs in (done by `simulator ssh attack`).

The golang binary now has a corresponding --attack-container-tag flag and configuration variable to control what this is set to.  This is written to tfvars during initialisation so that it propagates all the way through.

I have pushed a docker tag named "raoul" on the attack container

**How to test**

* checkout this branch and rebuild it with `make run`
* run `simulator infra create --attack-container-tag=raoul`
* log on to the bastion and check the ubuntu `.bash_login` to see that it will launch the correct (raoul) tag of the attack container

Sorry this is a massive pull request because it touches everything!  That couldn't be avoided but it has reminded me that I need to refactor the initialisation logic because the way it is currently addding new vars causes a cambrian explosion of changes like this