### PR TITLE
Feature request template

### DIFF
--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+**Feature statement**
+State the current approach (if exists), what the feature would provide, and the expected outcome.
+
+**Issue** 
+If this addresses/or enhances a issue, state what this issue is that this feature will resolve
+
+**Proposed approach**
+Outline at a high level how this feature would be implemented.  If many steps break these down into a bullet list.
+

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+blank_issues_enabled: false
+

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ The <code>start_task</code> command is used to inform the simulator which task y
 
 _Accessing hints_
 <pre>
-next_kind
+next_hint
 </pre>
 
 The <code>next_hint</code> command will provide a hint to help you complete the task you have started with the <code>start_task</code> command.


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feat: added feature request template, disabled access to blank template, highlighted in issue #76 

* **What is the current behavior?** (You can also link to an open issue here)
Presently there is not template for a feature request so a blank template must be selected

* **What is the new behavior (if this is a feature change)?**
When you raise an issue you will be presented with 2 templates to use, Issue and Feature Request.  No other options are available - blank template denied.
