### PR TITLE
feat(infra): tag AWS resources with the simulator bucket name

### DIFF
--- a/terraform/deployments/AWS/main.tf
+++ b/terraform/deployments/AWS/main.tf
@@ -1,11 +1,15 @@
 
+locals {
+  aws_tags = "${merge(var.default_tags, map("Simulator Bucket", "${data.terraform_remote_state.state.config.bucket}"))}"
+}
+
 // Setup networking
 module "Networking" {
   source              = "../../modules/AWS/Networking"
   vpc_cidr            = "${var.vpc_cidr}"
   public_subnet_cidr  = "${var.public_subnet_cidr}"
   private_subnet_cidr = "${var.private_subnet_cidr}"
-  default_tags        = "${var.default_tags}"
+  default_tags        = "${local.aws_tags}"
 }
 
 // Discovery AMI Id to use for all instances
@@ -31,7 +35,7 @@ module "Bastion" {
   master_ip_addresses  = "${join(",", "${module.Kubernetes.K8sMasterPrivateIp}")}"
   node_ip_addresses    = "${join(",", "${module.Kubernetes.K8sNodesPrivateIp}")}"
   attack_container_tag = "${var.attack_container_tag}"
-  default_tags         = "${var.default_tags}"
+  default_tags         = "${local.aws_tags}"
 }
 
 // Setup Kubernetes master and nodes
@@ -48,7 +52,7 @@ module "Kubernetes" {
   private_subnet_id           = "${module.Networking.PrivateSubnetId}"
   iam_instance_profile_id     = "${module.S3Storage.IamInstanceProfileId}"
   s3_bucket_name              = "${module.S3Storage.S3BucketName}"
-  default_tags                = "${var.default_tags}"
+  default_tags                = "${local.aws_tags}"
 }
 
 // Setup host within Kubernetes subnet
@@ -59,7 +63,7 @@ module "InternalNode" {
   access_key_name     = "${module.SshKey.KeyPairName}"
   control_plane_sg_id = "${module.SecurityGroups.ControlPlaneSecurityGroupID}"
   private_subnet_id   = "${module.Networking.PrivateSubnetId}"
-  default_tags        = "${var.default_tags}"
+  default_tags        = "${local.aws_tags}"
   bastion_public_ip   = "${module.Bastion.BastionPublicIp}"
 }
 
@@ -67,7 +71,7 @@ module "InternalNode" {
 // master and nodes
 module "S3Storage" {
   source         = "../../modules/AWS/S3Storage"
-  default_tags   = "${var.default_tags}"
+  default_tags   = "${local.aws_tags}"
 }
 
 // Define security groups
@@ -77,6 +81,5 @@ module "SecurityGroups" {
   vpc_id                    = "${module.Networking.VpcId}"
   public_subnet_cidr_block  = "${module.Networking.PublicSubnetCidrBlock}"
   private_subnet_cidr_block = "${module.Networking.PrivateSubnetCidrBlock}"
-  default_tags              = "${var.default_tags}"
+  default_tags              = "${local.aws_tags}"
 }
-

--- a/terraform/deployments/AWS/providers.tf
+++ b/terraform/deployments/AWS/providers.tf
@@ -7,9 +7,16 @@ provider "aws" {}
 terraform {
   backend "s3" {
     key = "simulator.tfstate"
-    bucket = "###REPLACED-BY-SIMULATOR###"
+    bucket = "###REPLACED-BY-SIMULATOR###" # Must have exact number of spaces for simulator to replace properly
     encrypt = false # Optional, S3 Bucket Server Side Encryption
   }
 }
 
-
+data "terraform_remote_state" "state" {
+  backend = "s3"
+  config  = {
+    key     = "simulator.tfstate"
+    bucket = "###REPLACED-BY-SIMULATOR###"  # Must have exact number of spaces for simulator to replace properly
+    encrypt = false # Optional, S3 Bucket Server Side Encryption
+  }
+}

--- a/terraform/deployments/AWS/providers.tf
+++ b/terraform/deployments/AWS/providers.tf
@@ -7,8 +7,10 @@ provider "aws" {}
 terraform {
   backend "s3" {
     key = "simulator.tfstate"
-    bucket = "###REPLACED-BY-SIMULATOR###" # Must have exact number of spaces for simulator to replace properly
-    encrypt = false # Optional, S3 Bucket Server Side Encryption
+    // 'bucket='' must have this exact number of spaces for simulator to replace it properly
+    bucket = "###REPLACED-BY-SIMULATOR###"
+    // Optional, S3 Bucket Server Side Encryption
+    encrypt = false
   }
 }
 
@@ -16,7 +18,9 @@ data "terraform_remote_state" "state" {
   backend = "s3"
   config  = {
     key     = "simulator.tfstate"
-    bucket = "###REPLACED-BY-SIMULATOR###"  # Must have exact number of spaces for simulator to replace properly
-    encrypt = false # Optional, S3 Bucket Server Side Encryption
+    // 'bucket='' must have this exact number of spaces for simulator to replace it properly
+    bucket = "###REPLACED-BY-SIMULATOR###"
+    // Optional, S3 Bucket Server Side Encryption
+    encrypt = false
   }
 }


### PR DESCRIPTION
Fixes #90 by adding a `terraform_remote_state` data source to the provisioner and inserting this value to the default tags map used by the other tf modules.
