### PR TITLE
feat: change ssh mount path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ else
 	SIMULATOR_AWS_CREDS_PATH := $(shell dirname $(AWS_SHARED_CREDENTIALS_FILE))
 endif
 
-SSH_CONFIG_PATH := $(HOME)/.ssh/
+SSH_CONFIG_PATH := $(HOME)/.kubesim/
 KUBE_SIM_TMP := $(HOME)/.kubesim/
 SIMULATOR_CONFIG_FILE := $(KUBE_SIM_TMP)/simulator.yaml
 HOST := $(shell hostname)

--- a/kubesim
+++ b/kubesim
@@ -7,7 +7,7 @@ else
 fi
 
 CONTAINER_NAME=controlplane/simulator:latest
-SSH_CONFIG_PATH=${HOME}/.ssh/
+SSH_CONFIG_PATH=${HOME}/.kubesim/
 KUBE_SIM_TMP=${HOME}/.kubesim/
 SIMULATOR_CONFIG_FILE=${KUBE_SIM_TMP}/simulator.yaml
 


### PR DESCRIPTION
Fixes #78 By changing the mount path used to store SSH keys to `${HOME}/.kubesim` to keep user SSH keys of the container and store all kubesim related files in one place.