### PR TITLE
feat: mount working dirs for make run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,12 +72,14 @@ gpg-preflight:
 
 # --- DOCKER
 run: validate-requirements docker-build ## Run the simulator - the build stage of the container runs all the cli tests
-	@docker run                                             \
-		-h launch                                           \
-		-v $(SIMULATOR_AWS_CREDS_PATH):/home/launch/.aws    \
-		-v $(SSH_CONFIG_PATH):/home/launch/.ssh             \
-		-v $(KUBE_SIM_TMP):/home/launch/.kubesim            \
-		--env-file launch-environment                       \
+	@docker run                                                     \
+		-h launch                                                     \
+		-v $(SIMULATOR_AWS_CREDS_PATH):/home/launch/.aws              \
+		-v $(SSH_CONFIG_PATH):/home/launch/.ssh                       \
+		-v $(KUBE_SIM_TMP):/home/launch/.kubesim                      \
+		-v $(shell pwd)/terraform:/app/terraform                      \
+		-v $(shell pwd)/simulation-scripts:/app/simulation-scripts:ro \
+		--env-file launch-environment                                 \
 		--rm --init -it $(CONTAINER_NAME_LATEST)
 
 .PHONY: docker-build-no-cache


### PR DESCRIPTION
Mount the terraform and simulation-script directories in `make run` so they can be edited and the changes reflected in the container without needing to re build it.

Due to the way we use TF a read-only mount cannot be used with /terraform. Future work should bypass this limitation.

Fixes #100 