### PR TITLE
Revert "feat(infra): tag AWS resources with the simulator bucket name"

### DIFF
--- a/terraform/deployments/AWS/providers.tf
+++ b/terraform/deployments/AWS/providers.tf
@@ -7,20 +7,9 @@ provider "aws" {}
 terraform {
   backend "s3" {
     key = "simulator.tfstate"
-    // 'bucket='' must have this exact number of spaces for simulator to replace it properly
     bucket = "###REPLACED-BY-SIMULATOR###"
-    // Optional, S3 Bucket Server Side Encryption
-    encrypt = false
+    encrypt = false # Optional, S3 Bucket Server Side Encryption
   }
 }
 
-data "terraform_remote_state" "state" {
-  backend = "s3"
-  config  = {
-    key     = "simulator.tfstate"
-    // 'bucket='' must have this exact number of spaces for simulator to replace it properly
-    bucket = "###REPLACED-BY-SIMULATOR###"
-    // Optional, S3 Bucket Server Side Encryption
-    encrypt = false
-  }
-}
+


### PR DESCRIPTION
Reverts kubernetes-simulator/simulator#96 as it was preventing `simulator infra create` with an empty S3 bucket.

Re-opens #90 