### PR TITLE
fix(tf): revert #96 as it was preventing tf init for new state

### DIFF
--- a/terraform/deployments/AWS/main.tf
+++ b/terraform/deployments/AWS/main.tf
@@ -1,6 +1,6 @@
 
 locals {
-  aws_tags = "${merge(var.default_tags, map("Simulator Bucket", "${data.terraform_remote_state.state.config.bucket}"))}"
+  aws_tags = "${var.default_tags}"
 }
 
 // Setup networking

--- a/terraform/deployments/AWS/providers.tf
+++ b/terraform/deployments/AWS/providers.tf
@@ -13,14 +13,3 @@ terraform {
     encrypt = false
   }
 }
-
-data "terraform_remote_state" "state" {
-  backend = "s3"
-  config  = {
-    key     = "simulator.tfstate"
-    // 'bucket='' must have this exact number of spaces for simulator to replace it properly
-    bucket = "###REPLACED-BY-SIMULATOR###"
-    // Optional, S3 Bucket Server Side Encryption
-    encrypt = false
-  }
-}


### PR DESCRIPTION
Reverts #96  and re-opens #90 as the current implementation is preventing `simulator infra create` when using a new S3 bucket with no tf state.
