### PR TITLE
fix(scen): minor hints update and do not check keys for attack ssh functions

### DIFF
--- a/attack/scripts/bashrc
+++ b/attack/scripts/bashrc
@@ -85,7 +85,7 @@ attack_master() {
     return 1
   fi
 
-  ssh root@"${MASTER_NODES[${INDEX}]}"
+  ssh -o "StrictHostKeyChecking=no" root@"${MASTER_NODES[${INDEX}]}"
 }
 readonly -f attack_master
 export -f attack_master
@@ -110,7 +110,7 @@ attack_node() {
     return 1
   fi
 
-  ssh root@"${WORKER_NODES[${INDEX}]}"
+  ssh -o "StrictHostKeyChecking=no" root@"${WORKER_NODES[${INDEX}]}"
 }
 readonly -f attack_node
 export -f attack_node

--- a/simulation-scripts/scenario/network-hammer-and-anvil/challenge.txt
+++ b/simulation-scripts/scenario/network-hammer-and-anvil/challenge.txt
@@ -8,7 +8,8 @@ Starting Point: frontend pods in the network-hammer-and-anvil namespace.
 Difficulty: Medium
 
 Task 1: Can you exfiltrate an old database backup as well as the current database state?
-Details: Place the files in '/exfiltrated' on $MASTER_IP_ADDRESSES using the root account with this base64'd SSH key: $BASE64_SSH_KEY
+Details: Place the files in '/exfiltrated' on $MASTER_IP_ADDRESSES using the root account with this base64'd SSH key:
+$BASE64_SSH_KEY
 Use 'base64 -d' to get the original key.
 
 Task 2: Which one Kubernetes resource could you ADD to the namespace to prevent this data from being exfiltrated from the database in the future?

--- a/simulation-scripts/scenario/network-hammer-and-anvil/tasks.yaml
+++ b/simulation-scripts/scenario/network-hammer-and-anvil/tasks.yaml
@@ -13,7 +13,9 @@ tasks:
       - text: >-
           I think Postgres doesn't need a password if you're reaching it from
           localhost.
+      - text: I can use pg_dump get the data from the database.
       - text: I wonder if there are any mount points in this container.
+      - text: Is there something there in /backups?
       - text: >-
           I have an IP and SSH key from the welcome text to this challenge, I
           can 'scp' my data to there.


### PR DESCRIPTION
Minor text fixes plus disable strict host key checking for the `attack_node` and `attack_master` functions in the attack container.
