### PR TITLE
feat(tf): add kubectl config to internal node and update attack helpers

### DIFF
--- a/attack/scripts/bashrc
+++ b/attack/scripts/bashrc
@@ -64,7 +64,7 @@ readonly -f info
 #
 # SSH helpers
 #
-attack_master() {
+ssh_master() {
   local INDEX="${1:-}"
 
   # shellcheck disable=SC2086
@@ -87,10 +87,10 @@ attack_master() {
 
   ssh -o "StrictHostKeyChecking=no" root@"${MASTER_NODES[${INDEX}]}"
 }
-readonly -f attack_master
-export -f attack_master
+readonly -f ssh_master
+export -f ssh_master
 
-attack_node() {
+ssh_node() {
   local INDEX="${1:-}"
 
   IFS=', ' read -r -a WORKER_NODES <<<"${NODE_IP_ADDRESSES}"
@@ -112,8 +112,12 @@ attack_node() {
 
   ssh -o "StrictHostKeyChecking=no" root@"${WORKER_NODES[${INDEX}]}"
 }
-readonly -f attack_node
-export -f attack_node
+readonly -f ssh_node
+export -f ssh_node
+
+ssh_internal() {
+  ssh -o "StrictHostKeyChecking=no" root@"${INTERNAL_NODE_IP}"
+}
 
 #
 # Display info message
@@ -121,17 +125,20 @@ export -f attack_node
 welcome() {
   IFS=', ' read -r -a MASTER_NODES <<<"${MASTER_IP_ADDRESSES}"
   IFS=', ' read -r -a WORKER_NODES <<<"${NODE_IP_ADDRESSES}"
-  info "You have made it inside the perimeter of a private kubernetes cluster."
+  info "You have found a private kubernetes cluster."
   info "There are ${BOLD}${#MASTER_NODES[@]}${NORMAL} master " \
     "and ${BOLD}${#WORKER_NODES[@]}${NORMAL} nodes in the cluster"
   info ' '
-  info "We have setup helpers to attack the master(s) and node(s)."
+  info "We have setup helpers to ssh to the master(s) and node(s)."
   info ' '
-  info "To attack a master:"
-  info "  \$ attack_master 0"
+  info "To ssh to a master:"
+  info "  \$ ssh_master 0"
   info ' '
-  info "To attack a node:"
-  info "  \$ attack_node 2"
+  info "To ssh to a node:"
+  info "  \$ ssh_node 1"
+  info ' '
+  info "To ssh to an instance with network access to the cluster"
+  info " \$ ssh_internal"
   info ' '
   info "To see this message again:"
   info "  \$ welcome"

--- a/simulation-scripts/scenario/node-shock-tactics/challenge.txt
+++ b/simulation-scripts/scenario/node-shock-tactics/challenge.txt
@@ -6,7 +6,7 @@ Starting Point: worker node, Alex user
 
 Difficulty: Medium
 
-NOTE: DO NOT USE 'attack_node' AS THIS WILL BYPASS THE SCENARIO AND GIVE YOU ROOT ACCESS TO THE NODE.
+NOTE: DO NOT USE 'ssh_node' AS THIS WILL BYPASS THE SCENARIO AND GIVE YOU ROOT ACCESS TO THE NODE.
 
 Task 1: Can you investigate the changes and escalate your permissions?
 

--- a/terraform/deployments/AWS/main.tf
+++ b/terraform/deployments/AWS/main.tf
@@ -26,16 +26,17 @@ module "SshKey" {
 
 // Setup Bastion host
 module "Bastion" {
-  source               = "../../modules/AWS/Bastion"
-  ami_id               = "${module.Ami.AmiId}"
-  instance_type        = "${var.instance_type}"
-  access_key_name      = "${module.SshKey.KeyPairName}"
-  security_group       = "${module.SecurityGroups.BastionSecurityGroupID}"
-  subnet_id            = "${module.Networking.PublicSubnetId}"
-  master_ip_addresses  = "${join(",", "${module.Kubernetes.K8sMasterPrivateIp}")}"
-  node_ip_addresses    = "${join(",", "${module.Kubernetes.K8sNodesPrivateIp}")}"
-  attack_container_tag = "${var.attack_container_tag}"
-  default_tags         = "${local.aws_tags}"
+  source                   = "../../modules/AWS/Bastion"
+  ami_id                   = "${module.Ami.AmiId}"
+  instance_type            = "${var.instance_type}"
+  access_key_name          = "${module.SshKey.KeyPairName}"
+  security_group           = "${module.SecurityGroups.BastionSecurityGroupID}"
+  subnet_id                = "${module.Networking.PublicSubnetId}"
+  master_ip_addresses      = "${join(",", "${module.Kubernetes.K8sMasterPrivateIp}")}"
+  node_ip_addresses        = "${join(",", "${module.Kubernetes.K8sNodesPrivateIp}")}"
+  internal_node_private_ip = "${module.InternalNode.InternalNodePrivateIp}"
+  attack_container_tag     = "${var.attack_container_tag}"
+  default_tags             = "${local.aws_tags}"
 }
 
 // Setup Kubernetes master and nodes
@@ -57,14 +58,16 @@ module "Kubernetes" {
 
 // Setup host within Kubernetes subnet
 module "InternalNode" {
-  source              = "../../modules/AWS/InternalNode"
-  ami_id              = "${module.Ami.AmiId}"
-  instance_type       = "${var.instance_type}"
-  access_key_name     = "${module.SshKey.KeyPairName}"
-  control_plane_sg_id = "${module.SecurityGroups.ControlPlaneSecurityGroupID}"
-  private_subnet_id   = "${module.Networking.PrivateSubnetId}"
-  default_tags        = "${local.aws_tags}"
-  bastion_public_ip   = "${module.Bastion.BastionPublicIp}"
+  source                   = "../../modules/AWS/InternalNode"
+  ami_id                   = "${module.Ami.AmiId}"
+  instance_type            = "${var.instance_type}"
+  access_key_name          = "${module.SshKey.KeyPairName}"
+  control_plane_sg_id      = "${module.SecurityGroups.ControlPlaneSecurityGroupID}"
+  private_subnet_id        = "${module.Networking.PrivateSubnetId}"
+  default_tags             = "${local.aws_tags}"
+  bastion_public_ip        = "${module.Bastion.BastionPublicIp}"
+  iam_instance_profile_id  = "${module.S3Storage.IamInstanceProfileId}"
+  s3_bucket_name           = "${module.S3Storage.S3BucketName}"
 }
 
 // Create S3 bucket to share Kubernetes join details between

--- a/terraform/modules/AWS/Bastion/cloud-config.tf
+++ b/terraform/modules/AWS/Bastion/cloud-config.tf
@@ -1,8 +1,9 @@
 data "template_file" "cloud_config" {
   template = "${file("${path.module}/cloud-config.yaml")}"
   vars = {
-    master_ip_addresses  = "${var.master_ip_addresses}"
-    node_ip_addresses    = "${var.node_ip_addresses}"
-    attack_container_tag = "${var.attack_container_tag}"
+    master_ip_addresses      = "${var.master_ip_addresses}"
+    node_ip_addresses        = "${var.node_ip_addresses}"
+    internal_node_private_ip = "${var.internal_node_private_ip}"
+    attack_container_tag     = "${var.attack_container_tag}"
   }
 }

--- a/terraform/modules/AWS/Bastion/cloud-config.yaml
+++ b/terraform/modules/AWS/Bastion/cloud-config.yaml
@@ -43,7 +43,8 @@ write_files:
     content: |
       export MASTER_IP_ADDRESSES=${master_ip_addresses}
       export NODE_IP_ADDRESSES=${node_ip_addresses}
-      sudo -E docker run -h attack -v /home/ubuntu/progress.json:/progress.json -v /home/ubuntu/tasks.yaml:/tasks.yaml -v /home/ubuntu/challenge.txt:/challenge.txt -e BASE64_SSH_KEY -e MASTER_IP_ADDRESSES -e NODE_IP_ADDRESSES -it controlplane/simulator-attack:${attack_container_tag}
+      export INTERNAL_NODE_IP=${internal_node_private_ip}
+      sudo -E docker run -h attack -v /home/ubuntu/progress.json:/progress.json -v /home/ubuntu/tasks.yaml:/tasks.yaml -v /home/ubuntu/challenge.txt:/challenge.txt -e BASE64_SSH_KEY -e MASTER_IP_ADDRESSES -e NODE_IP_ADDRESSES -e INTERNAL_NODE_IP -it controlplane/simulator-attack:${attack_container_tag}
   - path: /home/ubuntu/progress.json
     permissions: '0666'
     content: "{}"
@@ -106,7 +107,7 @@ write_files:
       X11DisplayOffset 10
       PrintMotd no
       PrintLastLog yes
-      TCPKeepAlive no 
+      TCPKeepAlive no
       ClientAliveInterval 30
       ClientAliveCountMax 240
       # Allow SendEnv of BASE64_SSH_KEY to enable SSHing to the instances in the

--- a/terraform/modules/AWS/Bastion/variables.tf
+++ b/terraform/modules/AWS/Bastion/variables.tf
@@ -37,3 +37,6 @@ variable "attack_container_tag" {
   description = "the docker tag of the attack container to use"
 }
 
+variable "internal_node_private_ip" {
+  description = "The Internal Node Private IP address"
+}

--- a/terraform/modules/AWS/InternalNode/internal-config.tf
+++ b/terraform/modules/AWS/InternalNode/internal-config.tf
@@ -1,5 +1,6 @@
 data "template_file" "internal_config" {
   template = "${file("${path.module}/internal-config.yaml")}"
+  vars = {
+    s3_bucket_name = "${var.s3_bucket_name}"
+  }
 }
-
-

--- a/terraform/modules/AWS/InternalNode/internal-config.yaml
+++ b/terraform/modules/AWS/InternalNode/internal-config.yaml
@@ -22,6 +22,7 @@ write_files:
       YP   YD ~Y8888P' Y8888P' Y88888P \`8888Y' Y888888P YP  YP  YP
       $(tput setaf 3)$(figlet $(hostname))
       $(tput sgr0)"
+      source <(kubectl completion bash)
   - path: /etc/default/motd-news
     owner: root:root
     permissions: '0644'
@@ -50,8 +51,9 @@ runcmd:
   - 'curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -'
   - 'echo "deb https://apt.kubernetes.io/ kubernetes-xenial main"  > /etc/apt/sources.list.d/kubernetes.list'
   - 'apt update'
-  - 'apt install -y kubectl'
+  - 'apt install -y kubectl awscli'
+  - 'mkdir -pv /root/.kube/'
+  - 'while true; do aws s3 ls s3://${s3_bucket_name}/config > /dev/null; if [ $? -ne 0 ]; then sleep 10; else break; fi; done && aws s3 cp s3://${s3_bucket_name}/config /root/.kube/ && aws s3 rm s3://${s3_bucket_name}/config'
 
 output:
   all: '| tee -a /var/log/cloud-init-output.log'
-

--- a/terraform/modules/AWS/InternalNode/main.tf
+++ b/terraform/modules/AWS/InternalNode/main.tf
@@ -7,6 +7,6 @@ resource "aws_instance" "simulator_internal_node" {
   associate_public_ip_address = false
   subnet_id                   = "${var.private_subnet_id}"
   user_data                   = "${data.template_file.internal_config.rendered}"
+  iam_instance_profile        = "${var.iam_instance_profile_id}"
   tags                        = "${merge(var.default_tags, map("Name", "Simulator Internal Node"))}"
 }
-

--- a/terraform/modules/AWS/InternalNode/variables.tf
+++ b/terraform/modules/AWS/InternalNode/variables.tf
@@ -29,3 +29,9 @@ variable "bastion_public_ip" {
   description = "IP address of the bastion for connecting to run tests"
 }
 
+variable "iam_instance_profile_id" {
+  description = "IAM instance S3 access profile id"
+}
+variable "s3_bucket_name" {
+  description = "Name  of s3 bucket"
+}

--- a/terraform/modules/AWS/Kubernetes/master-cloud-config.yaml
+++ b/terraform/modules/AWS/Kubernetes/master-cloud-config.yaml
@@ -62,6 +62,7 @@ runcmd:
   - 'kubectl --kubeconfig=/etc/kubernetes/admin.conf apply -f /run/download/calico.yaml'
   - "egrep -A 1 'kubeadm join' /var/log/cloud-init-output.log  |tr -d '\\' | tr -d '\n' > /tmp/join.txt"
   - 'aws s3 cp /tmp/join.txt s3://${s3_bucket_name}'
+  - 'aws s3 cp /root/.kube/config s3://${s3_bucket_name}'
 
 output:
   all: '| tee -a /var/log/cloud-init-output.log'

--- a/test/smoke.expect
+++ b/test/smoke.expect
@@ -53,7 +53,7 @@ expect {
 
 expect {
   "bash-5.0#" {
-    send "attack_master 0"
+    send "ssh_master 0"
   }
 }
 


### PR DESCRIPTION
Updates the internal node config to have kubectl access to the cluster. Also plumbs the internal node into the bastion and attack container config so it can be accessed trivially from the container. 

Updates the language in the attack container to be less aggressive.

Fixes #73 
