### PR TITLE
fix(go+peturb): reduce log output for expected double perturb errors

### DIFF
--- a/pkg/simulator/launch.go
+++ b/pkg/simulator/launch.go
@@ -63,7 +63,7 @@ func Launch(logger *zap.SugaredLogger, tfDir, scenariosDir, bucketName, id, atta
 	_, err = Perturb(&po)
 	if err != nil {
 		if strings.Contains(err.Error(), "exit status 3") {
-			logger.Info("Scenario clash error from perturb.sh")
+			logger.Error("Scenario clash error from perturb.sh")
 		} else {
 			return errors.Wrapf(err, "Error running perturb with %#v", po)
 		}

--- a/pkg/simulator/launch.go
+++ b/pkg/simulator/launch.go
@@ -5,6 +5,7 @@ import (
 	"github.com/controlplaneio/simulator-standalone/pkg/ssh"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
+	"strings"
 )
 
 // Launch runs perturb.sh to setup a scenario with the supplied `id` assuming
@@ -61,7 +62,11 @@ func Launch(logger *zap.SugaredLogger, tfDir, scenariosDir, bucketName, id, atta
 	logger.Infof("Setting up the \"%s\" scenario on the cluster", s.DisplayName)
 	_, err = Perturb(&po)
 	if err != nil {
-		return errors.Wrapf(err, "Error running perturb with %#v", po)
+		if strings.Contains(err.Error(), "exit status 3") {
+			logger.Info("Scenario clash error from perturb.sh")
+		} else {
+			return errors.Wrapf(err, "Error running perturb with %#v", po)
+		}
 	}
 
 	return nil

--- a/pkg/simulator/launch.go
+++ b/pkg/simulator/launch.go
@@ -62,7 +62,7 @@ func Launch(logger *zap.SugaredLogger, tfDir, scenariosDir, bucketName, id, atta
 	logger.Infof("Setting up the \"%s\" scenario on the cluster", s.DisplayName)
 	_, err = Perturb(&po)
 	if err != nil {
-		if strings.Contains(err.Error(), "exit status 3") {
+		if strings.Contains(err.Error(), "exit status 103") {
 			logger.Error("Scenario clash error from perturb.sh")
 		} else {
 			return errors.Wrapf(err, "Error running perturb with %#v", po)

--- a/simulation-scripts/perturb.sh
+++ b/simulation-scripts/perturb.sh
@@ -106,7 +106,8 @@ run_scenario() {
   local SCENARIO_DIR="${1}"
 
   if previously_perturbed ;then
-    error "This cluster has previously been perturbed"
+    warning "This cluster has previously been perturbed"
+    exit 103
   fi
 
   warning "Instructions in scenario:"

--- a/simulation-scripts/perturb.sh
+++ b/simulation-scripts/perturb.sh
@@ -106,7 +106,7 @@ run_scenario() {
   local SCENARIO_DIR="${1}"
 
   if previously_perturbed ;then
-    error "Perturbed has been previously run on this cluster"
+    error "This cluster has previously been perturbed"
   fi
 
   warning "Instructions in scenario:"


### PR DESCRIPTION
Reduce the log output for the expected errors when a user attempts to perturb the same cluster twice.

Fixes #123 