### PR TITLE
Perturb refactor to hide output

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,17 +74,19 @@ WORKDIR /app
 # Copy Dockerfiles, hadolint config and scripts
 COPY --chown=1000 scripts/ /app/scripts/
 COPY --chown=1000 attack/ /app/attack/
+COPY --chown=1000 simulation-scripts/ /app/simulation-scripts/
 COPY --chown=1000 kubesim /app/kubesim
 COPY --chown=1000 Dockerfile .hadolint.yaml /app/
 
 USER ${lint_user}
 
 # Lint Dockerfiles
-RUN hadolint Dockerfile            \
-    &&  hadolint attack/Dockerfile \
+RUN hadolint Dockerfile                         \
+    &&  hadolint attack/Dockerfile              \
 # Lint shell scripts
-    && shellcheck scripts/*        \
-    && shellcheck attack/scripts/* \
+    && shellcheck scripts/*                     \
+    && shellcheck attack/scripts/*              \
+    && shellcheck simulation-scripts/perturb.sh \
     && shellcheck kubesim
 
 WORKDIR /app/scenario-tools

--- a/pkg/simulator/perturb.go
+++ b/pkg/simulator/perturb.go
@@ -43,7 +43,7 @@ func (po *PerturbOptions) ToArguments() []string {
 	arguments := []string{"--master", po.Master.String()}
 	arguments = append(arguments, "--bastion")
 	arguments = append(arguments, po.Bastion.String())
-	arguments = append(arguments, "--slaves")
+	arguments = append(arguments, "--nodes")
 	slaves := ""
 	for index, slave := range po.Slaves {
 		slaves += slave.String()

--- a/pkg/simulator/perturb_test.go
+++ b/pkg/simulator/perturb_test.go
@@ -16,7 +16,7 @@ func Test_ToArguments_And_String(t *testing.T) {
 		Slaves:  []net.IP{net.IPv4(8, 8, 8, 8), net.IPv4(127, 0, 0, 2)},
 	}
 
-	assert.Equal(t, po.String(), "--master 127.0.0.1 --bastion 127.0.0.1 --slaves 8.8.8.8,127.0.0.2")
+	assert.Equal(t, po.String(), "--master 127.0.0.1 --bastion 127.0.0.1 --nodes 8.8.8.8,127.0.0.2")
 }
 
 func Test_MakePerturbOptions(t *testing.T) {

--- a/simulation-scripts/perturb.sh
+++ b/simulation-scripts/perturb.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+#shellcheck disable=SC1117
 #
 # Perturb Kubernetes Clusters
 #

--- a/simulation-scripts/perturb.sh
+++ b/simulation-scripts/perturb.sh
@@ -139,9 +139,9 @@ container_statuses() {
   local status
   status=$(echo "kubectl get pods --all-namespaces -o json" | run_ssh "$(get_master)" | jq -r '.items[].status.containerStatuses[].ready' | sort -u | tr '\n' ' ')
   if [[ $status == "true " ]]; then
-    return 1
-  else
     return 0
+  else
+    return 1
   fi
 }
 
@@ -155,7 +155,7 @@ get_pods() {
   increment="3"
   count="0"
 
-  while container_statuses && [[ count -le timeout ]]; do
+  while ! container_statuses && [[ count -le timeout ]]; do
     sleep $increment
     count=$((count+increment))
     if ! (( count % 9 )) ; then

--- a/simulation-scripts/perturb.sh
+++ b/simulation-scripts/perturb.sh
@@ -10,7 +10,7 @@
 ## Options:
 ##   --auto-populate [regex]    Pull master and slaves from doctl
 ##   -m, --master [string]      A Kubernetes API master host or IP (multi-master not supported)
-##   -s, --slaves [string]      Kubernetes slave hosts or IPs, comma-separated
+##   -n, --nodes [string]       Kubernetes node hosts or IPs, comma-separated
 ##   -b, --bastion [string]     Publicly accessible bastion server
 ##   --test                     Only run tests, do not deploy
 ##
@@ -55,9 +55,11 @@ EXPECTED_NUM_ARGUMENTS=1
 ARGUMENTS=()
 SCENARIO=''
 MASTER_HOST=""
-SLAVE_HOSTS=""
+NODE_HOSTS=""
 BASTION_HOST=""
 IS_FORCE=0
+TMP_DIR="/home/launch/.kubesim"
+FOUND_SCENARIO=""
 
 main() {
 
@@ -68,29 +70,40 @@ main() {
 
   local SCENARIO_DIR="scenario/${SCENARIO}/"
 
-  source test-func.sh
+  if ! is_master_accessible; then
+    error "Cannot connect to ${MASTER_HOST}"
+  fi
+  if ! is_node_accessible 1; then
+    error "Cannot connect to $(get_node 1)"
+  fi
+  if ! is_node_accessible 2; then
+    error "Cannot connect to $(get_node 2)"
+  fi
+  if [[ ! -d "${SCENARIO_DIR}" ]]; then
+    error "Scenario directory not found at ${SCENARIO_DIR}"
+  fi
 
-  local FOUND_SCENARIO
-  if FOUND_SCENARIO=$(find_scenario); then
-    if [[ "${IS_FORCE}" != 1 && "${FOUND_SCENARIO}" == "${SCENARIO}" ]]; then
+  fix_ioctl 1000
+  fix_ioctl 0
+  fix_ioctl 1
+  fix_ioctl 2
+
+  find_scenario
+
+  if [[ -n ${FOUND_SCENARIO} ]]; then
+    if [[ "${IS_FORCE}" != 1 ]]; then
       if ! is_special_scenario; then
-        error "Scenario ${SCENARIO} already deployed, reset deployment with 'cleanup' first"
+        warning "Scenario ${FOUND_SCENARIO} already deployed"
+        exit 103
       fi
     fi
-    info "Found scenario ${FOUND_SCENARIO}"
   fi
 
   info "Running ${SCENARIO_DIR} against ${MASTER_HOST}"
 
-  if ! is_master_accessible; then
-    error "Cannot connect to ${MASTER_HOST}"
-  elif [[ ! -d "${SCENARIO_DIR}" ]]; then
-    error "Scenario directory not found at ${SCENARIO_DIR}"
-  fi
-
   run_scenario "${SCENARIO_DIR}"
 
-  success "${SCENARIO_DIR} applied to ${MASTER_HOST} (master) and ${SLAVE_HOSTS} (slaves)"
+  success "${SCENARIO_DIR} applied to ${MASTER_HOST} (master) and ${NODE_HOSTS} (nodes)"
 
   success "End of perturb"
 }
@@ -105,13 +118,6 @@ is_special_scenario() {
 run_scenario() {
   local SCENARIO_DIR="${1}"
 
-  if previously_perturbed ;then
-    error "Perturbed has been previously run on this cluster"
-  fi
-
-  warning "Instructions in scenario:"
-  ls -lasp "${SCENARIO_DIR}"
-
   validate_instructions "${SCENARIO_DIR}"
 
   run_kubectl_yaml "${SCENARIO_DIR}"
@@ -123,28 +129,52 @@ run_scenario() {
   get_pods
 
   copy_challenge_and_tasks "${SCENARIO_DIR}"
-
-  lock_perturb
 }
 
 get_pods() {
   # sleep to ensure all pods are initialised
+  info "Waiting for all pods to be initalised..."
   sleep 30
   local QUERY_DOCKER="docker inspect \$(docker ps -aq)"
   local QUERY_KUBECTL="kubectl get pods --all-namespaces -o json"
-  local TMP_DIR="/home/launch/.kubesim"
   local TMP_FILE="${TMP_DIR}/docker-"
-  local SLAVE_1
-  local SLAVE_2
-  local MASTER_1
 
   echo "${QUERY_DOCKER}" | run_ssh "$(get_master)" >| "${TMP_FILE}"master
   echo "${QUERY_KUBECTL}" | run_ssh "$(get_master)" >| "${TMP_FILE}"all-pods
-  echo "${QUERY_DOCKER}" | run_ssh "$(get_slave 1)" >| "${TMP_FILE}"slave-1
-  echo "${QUERY_DOCKER}" | run_ssh "$(get_slave 2)" >| "${TMP_FILE}"slave-2
+  echo "${QUERY_DOCKER}" | run_ssh "$(get_node 1)" >| "${TMP_FILE}"node-1
+  echo "${QUERY_DOCKER}" | run_ssh "$(get_node 2)" >| "${TMP_FILE}"node-2
 
 #  tail -n +2 -q "${TMP_DIR}"/docker-slave-* |egrep -v pause\|kube-proxy\|calico | awk '{print$3"="$1}' |sed 's/\//\-/' > "${TMP_DIR}"/scenario-slave-pods.env
 }
+
+fix_ioctl() {
+  if [[ ${1} -eq "1000" ]]; then
+    ssh \
+      -F "${SSH_CONFIG_FILE}"  \
+      -o "StrictHostKeyChecking=no" \
+      -o "UserKnownHostsFile=/dev/null" \
+      -o "ConnectTimeout 3" \
+      -o "LogLevel=QUIET" \
+      "root@${BASTION_HOST}" "sed -i 's/mesg\ n\ ||\ true/tty\ \-s\ \&\&\ mesg n\ ||\ true/g' ~/.profile"
+  elif [[ ${1} -eq "0" ]]; then
+    ssh \
+      -F "${SSH_CONFIG_FILE}"  \
+      -o "StrictHostKeyChecking=no" \
+      -o "UserKnownHostsFile=/dev/null" \
+      -o "ConnectTimeout 3" \
+      -o "LogLevel=QUIET" \
+      "root@$(get_master)" "sed -i 's/mesg\ n\ ||\ true/tty\ \-s\ \&\&\ mesg n\ ||\ true/g' ~/.profile"
+  else
+    ssh \
+      -F "${SSH_CONFIG_FILE}"  \
+      -o "StrictHostKeyChecking=no" \
+      -o "UserKnownHostsFile=/dev/null" \
+      -o "ConnectTimeout 3" \
+      -o "LogLevel=QUIET" \
+      "root@$(get_node ${1})" "sed -i 's/mesg\ n\ ||\ true/tty\ \-s\ \&\&\ mesg n\ ||\ true/g' ~/.profile"
+  fi
+}
+
 
 is_master_accessible() {
   if [[ "${IS_SKIP_CHECK:-}" == 1 ]]; then
@@ -155,34 +185,64 @@ is_master_accessible() {
     -o "StrictHostKeyChecking=no" \
     -o "UserKnownHostsFile=/dev/null" \
     -o "ConnectTimeout 3" \
+    -o "LogLevel=QUIET" \
     "$(get_connection_string)" \
+    true
+}
+
+is_node_accessible() {
+  if [[ "${IS_SKIP_CHECK:-}" == 1 ]]; then
+    return 0
+  fi
+
+  ssh \
+    -F "${SSH_CONFIG_FILE}"  \
+    -o "StrictHostKeyChecking=no" \
+    -o "UserKnownHostsFile=/dev/null" \
+    -o "ConnectTimeout 3" \
+    -o "LogLevel=QUIET" \
+    "root@$(get_node ${1})" \
     true
 }
 
 copy_challenge_and_tasks() {
   local SCENARIO_DIR="${1}"
 
-  pushd "${SCENARIO_DIR}"
-  info "Copying challenge.txt from ${SCENARIO_DIR} to ${BASTION_HOST}"
+  pushd "${SCENARIO_DIR}" > /dev/null
   tmpchallenge=$(mktemp)
+  tmphash=$(mktemp)
+  base64 -w0 challenge.txt >| ${tmphash}
   cp challenge.txt ${tmpchallenge}
   if grep '##IP\|##NAME\|##HIP' challenge.txt > /dev/null; then
     template_challenge
   fi
 
+  info "Copying challenge.txt from ${SCENARIO_DIR} to ${BASTION_HOST}"
   scp \
     -F "${SSH_CONFIG_FILE}"  \
     -o "StrictHostKeyChecking=no" \
     -o "UserKnownHostsFile=/dev/null" \
+    -o "LogLevel=ERROR" \
     ${tmpchallenge} root@${BASTION_HOST}:/home/ubuntu/challenge.txt
-  info "Copying tasks.yaml from ${SCENARIO_DIR} to ${BASTION_HOST}"
   rm ${tmpchallenge}
+
+  info "Copying scenario hash from ${SCENARIO_DIR} to ${BASTION_HOST}"
   scp \
     -F "${SSH_CONFIG_FILE}"  \
     -o "StrictHostKeyChecking=no" \
     -o "UserKnownHostsFile=/dev/null" \
+    -o "LogLevel=ERROR" \
+    ${tmphash} root@${BASTION_HOST}:/home/ubuntu/hash.txt
+  rm ${tmphash}
+
+  info "Copying tasks.yaml from ${SCENARIO_DIR} to ${BASTION_HOST}"
+  scp \
+    -F "${SSH_CONFIG_FILE}"  \
+    -o "StrictHostKeyChecking=no" \
+    -o "UserKnownHostsFile=/dev/null" \
+    -o "LogLevel=ERROR" \
     tasks.yaml root@${BASTION_HOST}:/home/ubuntu/tasks.yaml
-  popd
+  popd > /dev/null
 }
 
 template_challenge() {
@@ -210,22 +270,27 @@ template_challenge() {
   fi
 }
 
-previously_perturbed() {
-  ssh \
-    -F "${SSH_CONFIG_FILE}"  \
-    -o "StrictHostKeyChecking=no" \
-    -o "UserKnownHostsFile=/dev/null" \
-    -o "ConnectTimeout 3" \
-    root@${MASTER_HOST} "[ -f /tmp/perturbed.lock ] && true || false"
-}
+find_scenario() {
+  local CHALLENGE_HASH
 
-lock_perturb() {
-  ssh \
-    -F "${SSH_CONFIG_FILE}"  \
-    -o "StrictHostKeyChecking=no" \
-    -o "UserKnownHostsFile=/dev/null" \
-    -o "ConnectTimeout 3" \
-    root@${MASTER_HOST} "touch /tmp/perturbed.lock"
+  CHALLENGE_HASH=$(echo 'cat /home/ubuntu/hash.txt 2>/dev/null || true; echo' | run_ssh "${BASTION_HOST}" | tail -n1)
+
+  if [[ "${CHALLENGE_HASH:-}" != "" ]]; then
+    for CHALLENGE in scenario/**/challenge.txt; do
+      THIS_CHALLENGE=$(cat "${CHALLENGE}" | base64 -w0)
+      if [[ "${THIS_CHALLENGE}" == "${CHALLENGE_HASH}" ]]; then
+        FOUND_SCENARIO=$(basename $(dirname "${CHALLENGE}"))
+        info "Installed scenario found: ${FOUND_SCENARIO}"
+        break
+      fi
+    done
+    if [[ -z ${FOUND_SCENARIO} ]]; then
+      info "Hash found but it does not match a known scenario"
+      FOUND_SCENARIO="Unknown Scenario"
+    fi
+  else
+    info "No scenario hash found"
+  fi
 }
 
 validate_instructions() {
@@ -233,7 +298,6 @@ validate_instructions() {
 
   shopt -s extglob
   for FILE in "${SCENARIO_DIR%/}/"*.{sh,do,txt}; do
-    echo "${FILE}"
     local TYPE; TYPE="$(basename "${FILE}")"
     case "${TYPE}" in
       *worker-any.sh) ;;
@@ -277,15 +341,15 @@ run_kubectl_yaml() {
       # shellcheck disable=SC2185
       FILES=$(find -regex '.*.ya?ml')
 
-      info "running remotely: kubectl ${ACTION} -f ${FILES}"
-
       FILES_STRING=$(for FILE in ${FILES}; do
         cat "${FILE}"
         echo '---'
       done)
 
-      echo "${FILES_STRING}" | run_ssh "${HOST}" kubectl "${ACTION}" --dry-run -f -
-      echo "${FILES_STRING}" | run_ssh "${HOST}" kubectl "${ACTION}" -f -
+      info "Testing kube yamls are valid"
+      echo "${FILES_STRING}" | run_ssh "${HOST}" kubectl "${ACTION}" --dry-run -f - &> /dev/null
+      info "Applying kube yamls to the cluster"
+      echo "${FILES_STRING}" | run_ssh "${HOST}" kubectl "${ACTION}" -f - &> /dev/null
     )
   done
 }
@@ -296,27 +360,27 @@ run_scripts() {
   shopt -s extglob
 
   for FILE in "${SCENARIO_DIR%/}/"*.sh; do
-    echo "${FILE}"
+    info "Running script files. This may take 1-2 mins"
     local TYPE; TYPE="$(basename "${FILE}")"
     case "${TYPE}" in
 
       *worker-any.sh)
-        run_file_on_host "${FILE}" "$(get_slave 0)"
+        run_file_on_host "${FILE}" "$(get_node 0)"
         ;;
       *worker-1.sh)
-        run_file_on_host "${FILE}" "$(get_slave 1)"
+        run_file_on_host "${FILE}" "$(get_node 1)"
         ;;
       *worker-2.sh)
-        run_file_on_host "${FILE}" "$(get_slave 2)"
+        run_file_on_host "${FILE}" "$(get_node 2)"
         ;;
       *workers-every.sh)
-        run_file_on_host "${FILE}" "$(get_slave 1)"
-        run_file_on_host "${FILE}" "$(get_slave 2)"
+        run_file_on_host "${FILE}" "$(get_node 1)"
+        run_file_on_host "${FILE}" "$(get_node 2)"
         ;;
       *nodes-every.sh)
         run_file_on_host "${FILE}" "$(get_master)"
-        run_file_on_host "${FILE}" "$(get_slave 1)"
-        run_file_on_host "${FILE}" "$(get_slave 2)"
+        run_file_on_host "${FILE}" "$(get_node 1)"
+        run_file_on_host "${FILE}" "$(get_node 2)"
         ;;
       *master.sh)
         run_file_on_host "${FILE}" "$(get_master)"
@@ -335,7 +399,7 @@ run_scripts() {
 }
 
 run_cleanup() {
-  warning 'Cleanup started'
+  info 'Cleanup started'
 
   local SCENARIO_DIR="${1}"
 
@@ -348,7 +412,7 @@ run_cleanup() {
   # cover tracks on all nodes, reboot all nodes if required
 
   if [[ ! -f "${SCENARIO_DIR}/no-cleanup.do" ]]; then
-    info "Covering tracks..."
+    info "Covering tracks"
     SCRIPTS_TO_RUN+=" ${COVER_TRACKS_SCRIPT}"
   fi
 
@@ -365,16 +429,14 @@ run_cleanup() {
 
     TEMP_FILE=$(mktemp)
     # shellcheck disable=SC2140
-    echo "echo 'cat ""${SCENARIO_DIR}"challenge.txt"' > /opt/challenge.txt" | tee "${TEMP_FILE}"
+    echo "echo 'cat ""${SCENARIO_DIR}"challenge.txt"' > /opt/challenge.txt" >| "${TEMP_FILE}"
     SCRIPTS_TO_RUN+=" ${TEMP_FILE}"
   fi
 
-  warning "Running script '${SCRIPTS_TO_RUN}'"
-
   for FILE_TO_RUN in ${SCRIPTS_TO_RUN}; do
     get_file_to_run "${FILE_TO_RUN}" | run_ssh "$(get_master)" || true
-    get_file_to_run "${FILE_TO_RUN}" | run_ssh "$(get_slave 1)" || true
-    get_file_to_run "${FILE_TO_RUN}" | run_ssh "$(get_slave 2)" || true
+    get_file_to_run "${FILE_TO_RUN}" | run_ssh "$(get_node 1)" || true
+    get_file_to_run "${FILE_TO_RUN}" | run_ssh "$(get_node 2)" || true
   done
 
   # reboot master or workers if required
@@ -384,8 +446,8 @@ run_cleanup() {
   fi
 
   if [[ -f "${SCENARIO_DIR}/reboot-workers.do" ]]; then
-    get_file_to_run "${REBOOT_SCRIPT}" | run_ssh "$(get_slave 1)" || true
-    get_file_to_run "${REBOOT_SCRIPT}" | run_ssh "$(get_slave 2)" || true
+    get_file_to_run "${REBOOT_SCRIPT}" | run_ssh "$(get_node 1)" || true
+    get_file_to_run "${REBOOT_SCRIPT}" | run_ssh "$(get_node 2)" || true
   fi
 }
 
@@ -395,18 +457,17 @@ run_ssh() {
     -F "${SSH_CONFIG_FILE}" \
     -o "StrictHostKeyChecking=no" \
     -o "UserKnownHostsFile=/dev/null" \
+    -o "LogLevel=ERROR" \
     root@"${@}"
 }
 
 get_file_to_run() {
   local FILE="${1}"
-  echo "set -x"
   if [[ "${IS_DRY_RUN:-}" == 1 ]]; then
     cat "${FILE}" >&2
   else
     cat "${FILE}"
   fi
-  echo "echo PERTURBANCE COMPLETE FOR ${FILE} ON \$(hostname) AT \$(date)"
   echo
 }
 
@@ -414,23 +475,28 @@ run_file_on_host() {
   local FILE="${1}"
   local HOST="${2}"
   (
+    touch "${TMP_DIR}/perturb-script-file-${HOST}.log"
+    exec 19>>"${TMP_DIR}/perturb-script-file-${HOST}.log"
+    BASH_XTRACEFD=19
     set -x
-    get_file_to_run "${FILE}"
-  ) | run_ssh "${HOST}"
+    get_file_to_run "${FILE}" >> "${TMP_DIR}/perturb-script-file-${HOST}.log" 2>&1
+  ) | run_ssh "${HOST}" >> "${TMP_DIR}/perturb-script-file-${HOST}.log" 2>&1 && \
+  rm "${TMP_DIR}/perturb-script-file-${HOST}.log"
+  unset BASH_XTRACEFD
 }
 
 get_master() {
   echo "${MASTER_HOST}"
 }
 
-get_slave() {
+get_node() {
   local INDEX="${1:-1}"
   local CAT_SORT="cat"
   if [[ "${INDEX}" == 0 ]]; then
     CAT_SORT='sort --random-sort'
     INDEX=1
   fi
-  echo "${SLAVE_HOSTS}" \
+  echo "${NODE_HOSTS}" \
     | tr ',' '\n' \
     | ${CAT_SORT} \
     | sed -n "${INDEX}p"
@@ -464,10 +530,10 @@ parse_arguments() {
         not_empty_or_usage "${1:-}"
         MASTER_HOST="${1}"
         ;;
-      -s | --slaves)
+      -n | --nodes)
         shift
         not_empty_or_usage "${1:-}"
-        SLAVE_HOSTS="${1}"
+        NODE_HOSTS="${1}"
         ;;
       -b | --bastion)
         shift
@@ -501,7 +567,7 @@ get_cluster_master() {
   echo "${IPS}" | head -n1
 }
 
-get_cluster_slaves() {
+get_cluster_nodes() {
   local IPS
   IPS=$(get_node_ips)
   echo "${IPS}" | tail -n +2 | tr '\n' ','
@@ -516,13 +582,13 @@ validate_arguments() {
       set -e
       get_cluster_master
     )
-    SLAVE_HOSTS=$(
+    NODE_HOSTS=$(
       set -e
-      get_cluster_slaves
+      get_cluster_nodes
     )
   else
     [[ ${MASTER_HOST:-} ]] || error "--master must be an IP or hostname, or comma-delimited list"
-    [[ ${SLAVE_HOSTS:-} ]] || error "--slaves must be an IP or hostname, or comma-delimited list"
+    [[ ${NODE_HOSTS:-} ]] || error "--nodes must be an IP or hostname, or comma-delimited list"
   fi
 
   SCENARIO="${ARGUMENTS[0]:-}" || true
@@ -540,12 +606,12 @@ usage() {
 success() {
   [ "${*:-}" ] && RESPONSE="$*" || RESPONSE="Unknown Success"
   printf "%s\n" "$(log_message_prefix)${COLOUR_GREEN}${RESPONSE}${COLOUR_RESET}"
-} 1>&2
+}
 
 info() {
   [ "${*:-}" ] && INFO="$*" || INFO="Unknown Info"
-  printf "%s\n" "$(log_message_prefix)${COLOUR_WHITE}${INFO}${COLOUR_RESET}"
-} 1>&2
+  printf "%s\n" "$(log_message_prefix)${COLOUR_BLUE}${INFO}${COLOUR_RESET}"
+}
 
 warning() {
   [ "${*:-}" ] && ERROR="$*" || ERROR="Unknown Warning"
@@ -582,6 +648,7 @@ not_empty_or_usage() {
 TERM="xterm-color"
 COLOUR_RED=$(tput setaf 1 :-"" 2>/dev/null)
 COLOUR_GREEN=$(tput setaf 2 :-"" 2>/dev/null)
+COLOUR_BLUE=$(tput setaf 4 :-"" 2>/dev/null)
 COLOUR_WHITE=$(tput setaf 7 :-"" 2>/dev/null)
 COLOUR_RESET=$(tput sgr0 :-"" 2>/dev/null)
 

--- a/simulation-scripts/scenario/etcd-inverted-wedge/master.sh
+++ b/simulation-scripts/scenario/etcd-inverted-wedge/master.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-add-apt-repository ppa:rmescandon/yq &> /dev/null
-apt update &> /dev/null
-apt install -y jq yq &> /dev/null
+add-apt-repository ppa:rmescandon/yq
+apt update
+apt install -y jq yq
 
 yq r -j /etc/kubernetes/manifests/etcd.yaml | jq --arg auth "--client-cert-auth=true" '(.spec.containers[].command[] | select(. == $auth)) = "--client-cert-auth=false"' | yq r - > etcd.yaml
 mv etcd.yaml /etc/kubernetes/manifests/etcd.yaml

--- a/simulation-scripts/scenario/master-encirclement/master.sh
+++ b/simulation-scripts/scenario/master-encirclement/master.sh
@@ -1,23 +1,23 @@
 #!/bin/bash
 
-git clone https://github.com/controlplaneio/kubesec-webhook.git webhook &> /dev/null
+git clone https://github.com/controlplaneio/kubesec-webhook.git webhook
 
 cd webhook
 
-apt update && apt install -y make &> /dev/null
+apt update && apt install -y make
 
-make certs &> /dev/null
+make certs
 
-make deploy &> /dev/null
+make deploy
 
 cd ..
 
-rm -rf webhook  &> /dev/null
+rm -rf webhook
 
-kubectl create namespace master-encirclement &> /dev/null
+kubectl create namespace master-encirclement
 
-kubectl label namespaces master-encirclement kubesec-validation=enabled &> /dev/null
+kubectl label namespaces master-encirclement kubesec-validation=enabled
 
 sed -i '18i\ \ \ \ \- --disable-admission-plugins=MutatingAdmissionWebhook' /etc/kubernetes/manifests/kube-apiserver.yaml
 
-apt remove -y make  &> /dev/null
+apt remove -y make 

--- a/simulation-scripts/scenario/node-amphibious-operations/workers-every.sh
+++ b/simulation-scripts/scenario/node-amphibious-operations/workers-every.sh
@@ -1,6 +1,6 @@
-add-apt-repository ppa:rmescandon/yq &> /dev/null
-apt update &> /dev/null
-apt install yq -y &> /dev/null
+add-apt-repository ppa:rmescandon/yq
+apt update
+apt install yq -y
 
 yq w -i /var/lib/kubelet/config.yaml authentication.anonymous.enabled true
 yq w -i /var/lib/kubelet/config.yaml authorization.mode AlwaysAllow

--- a/simulation-scripts/scenario/node-amphibious-operations/workers-every.sh
+++ b/simulation-scripts/scenario/node-amphibious-operations/workers-every.sh
@@ -1,3 +1,5 @@
+#! /bin/bash
+
 add-apt-repository ppa:rmescandon/yq
 apt update
 apt install yq -y

--- a/simulation-scripts/scenario/policy-fire-support/workers-every.sh
+++ b/simulation-scripts/scenario/policy-fire-support/workers-every.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-mkdir -pv /root/.ssh && ssh-keygen -C root -b 4096 -t rsa -N "" -f /root/.ssh/id_rsa &> /dev/null
-docker build -t jenkins:policy-fire-support - &> /dev/null <<EOF
+mkdir -pv /root/.ssh && ssh-keygen -C root -b 4096 -t rsa -N "" -f /root/.ssh/id_rsa
+docker build -t jenkins:policy-fire-support - <<EOF
 
 FROM jenkins
 

--- a/simulation-scripts/scenario/secret-high-ground/workers-every.sh
+++ b/simulation-scripts/scenario/secret-high-ground/workers-every.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-docker build -t jenkins/jenkins:lts-alpine - &> /dev/null <<EOF
+docker build -t jenkins/jenkins:lts-alpine - <<EOF
 FROM jenkins/jenkins:lts-alpine
 
 USER root

--- a/simulation-scripts/test-func.sh
+++ b/simulation-scripts/test-func.sh
@@ -1,66 +1,66 @@
-test_scenario() {
+# test_scenario() {
+#
+#   local SCENARIO="${1:-}"
+#   local FOUND_SCENARIO="${SCENARIO}"
+#
+#   if [[ "${FOUND_SCENARIO:-}" == "" ]]; then
+#     # if no hash found, but we want to find a test script
+#     if ! FOUND_SCENARIO=$(find_scenario); then
+#
+#       if [[ "${SCENARIO:-}" != "" ]]; then
+#         info "Scenario passed to function, using ${SCENARIO}"
+#         FOUND_SCENARIO="${SCENARIO}"
+#       else
+#         warning "No scenario found"
+#         return 99
+#       fi
+#     fi
+#   fi
+#
+#   local TEST_SCRIPT="scenario/${FOUND_SCENARIO:-___empty}/test.sh"
+#
+#   if [[ -f "${TEST_SCRIPT}" ]]; then
+#     info "Tests running from ${TEST_SCRIPT}"
+#     ( source "${TEST_SCRIPT}" )
+#     return $?
+#   else
+#     warning "Test script not found at: ${TEST_SCRIPT}"
+#     return 99
+#   fi
+#
+#   return 1
+# }
 
-  local SCENARIO="${1:-}"
-  local FOUND_SCENARIO="${SCENARIO}"
+# find_scenario() {
+#
+#   local CHALLENGE_HASH
+#   local FOUND_SCENARIO=""
+#
+#   CHALLENGE_HASH=$(echo 'cat /home/ubuntu/hash.txt 2>/dev/null || true; echo' | run_ssh "${BASTION_HOST}" | tail -n1)
+#
+#   if [[ "${CHALLENGE_HASH:-}" != "" ]]; then
+#     for CHALLENGE in scenario/**/challenge.txt; do
+#       THIS_CHALLENGE=$(cat "${CHALLENGE}" | base64 -w0)
+#       if [[ "${THIS_CHALLENGE}" == "${CHALLENGE_HASH}" ]]; then
+#         FOUND_SCENARIO=$(basename $(dirname "${CHALLENGE}"))
+#         info "Installed scenario found: ${FOUND_SCENARIO}"
+#         break
+#       fi
+#     done
+#     if [[ -n ${FOUND_SCENARIO} ]]; then
+#       info "Hash found but is does not match a known scenario"
+#     fi
+#   else
+#     info "No hash found"
+#   fi
+# }
 
-  if [[ "${FOUND_SCENARIO:-}" == "" ]]; then
-    # if no hash found, but we want to find a test script
-    if ! FOUND_SCENARIO=$(find_scenario); then
-
-      if [[ "${SCENARIO:-}" != "" ]]; then
-        info "Scenario passed to function, using ${SCENARIO}"
-        FOUND_SCENARIO="${SCENARIO}"
-      else
-        warning "No scenario found"
-        return 99
-      fi
-    fi
-  fi
-
-  local TEST_SCRIPT="scenario/${FOUND_SCENARIO:-___empty}/test.sh"
-
-  if [[ -f "${TEST_SCRIPT}" ]]; then
-    info "Tests running from ${TEST_SCRIPT}"
-    ( source "${TEST_SCRIPT}" )
-    return $?
-  else
-    warning "Test script not found at: ${TEST_SCRIPT}"
-    return 99
-  fi
-
-  return 1
-}
-
-find_scenario() {
-
-  local CHALLENGE_HASH
-  local FOUND_SCENARIO=""
-
-  CHALLENGE_HASH=$(echo 'cat /opt/challenge.txt && { echo ; base64 -w0 /opt/challenge.txt; }; echo' | run_ssh "$(get_master)" | tail -n1)
-
-  if [[ "${CHALLENGE_HASH:-}" != "" ]]; then
-    warning "SCENARIO hash: ${CHALLENGE_HASH}"
-    for CHALLENGE in scenario/**/challenge.txt; do
-      THIS_CHALLENGE=$(cat "${CHALLENGE}" | base64 -w0)
-      if [[ "${THIS_CHALLENGE}" == "${CHALLENGE_HASH}" ]]; then
-        FOUND_SCENARIO=$(basename $(dirname "${CHALLENGE}"))
-        info "Installed scenario found: ${FOUND_SCENARIO}"
-        break
-      fi
-    done
-  else
-    info "No hash found"
-  fi
-
-  echo "${FOUND_SCENARIO}"
-}
-
-read_prompt() {
-  local IS_PROCEED
-  echo
-  read -n 1 -p "Proceed? [n/q/Y] " IS_PROCEED
-  local IS_PROCEED=$(echo "${IS_PROCEED}" | tr '[A-Z]' '[a-z]')
-  echo
-  [[ "${IS_PROCEED}" = n || "${IS_PROCEED}" = q ]] && return 1
-  return 0
-}
+# read_prompt() {
+#   local IS_PROCEED
+#   echo
+#   read -n 1 -p "Proceed? [n/q/Y] " IS_PROCEED
+#   local IS_PROCEED=$(echo "${IS_PROCEED}" | tr '[A-Z]' '[a-z]')
+#   echo
+#   [[ "${IS_PROCEED}" = n || "${IS_PROCEED}" = q ]] && return 1
+#   return 0
+# }

--- a/simulation-scripts/test-func.sh
+++ b/simulation-scripts/test-func.sh
@@ -1,3 +1,5 @@
+#! /bin/bash
+
 # test_scenario() {
 #
 #   local SCENARIO="${1:-}"


### PR DESCRIPTION
Large refactor of perturb to hide extraneous `stdout` and `stderr` output.  Changes of note include:

* `warnings` are mostly replaced with `info`s so users don't see red text during normal operation.
* `info` and `success` no longer redirect to `stderr` so output at the correct time in the script instead of sitting in `stderr` until script completion.
* `info` outputs in blue for use across light and dark terminals.
* The `find_scenario` function is brought into the script and fixed to function properly. 
* `test_funcs.sh` is deprecated and commented out as no functions in there are being used.
* Since `found_scenario` is now functional, a minor change was made to replace the `lock_perturb` functions with more granular functionality. 
* Scenario challenge hashes are stored on the cluster so they will still match despite templating the challenge during the apply steps.
*  'slaves' is replaced with 'nodes' throughout the script to reflect proper kubernetes project terminology.
* trivial edits to the go and tests were made to support this
* nodes are now tested for connectability as well as the master.
* master and node connection tests are moved to earlier in the script before any commands to those hosts are run.
* ioctl errors have been fixed by editing the bash profile on the remote servers.
* scenarios log output to local log file that is deleted on success.
* scenarios have redirects to `/dev/null` removed as this is now handled by perturb.

Fixes #74  #91 

Depends on #132 