### PR TITLE
feat(go): Change timestamp from Epoc to ISO0860 for human readability

### DIFF
--- a/cmd/logger.go
+++ b/cmd/logger.go
@@ -32,7 +32,7 @@ func newLogger(logLevel string, zapEncoding string) (*zap.SugaredLogger, error) 
 		StacktraceKey:  "stacktrace",
 		LineEnding:     zapcore.DefaultLineEnding,
 		EncodeLevel:    zapcore.CapitalColorLevelEncoder,
-		EncodeTime:     zapcore.EpochTimeEncoder,
+		EncodeTime:     zapcore.ISO8601TimeEncoder,
 		EncodeDuration: zapcore.SecondsDurationEncoder,
 		EncodeCaller:   zapcore.ShortCallerEncoder,
 	}


### PR DESCRIPTION
Fixes #138 