### PR TITLE
Golangci lint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -101,6 +101,7 @@ RUN apt-get update                                                              
     awscli                                                                       \
     build-essential                                                              \
     ca-certificates                                                              \
+    curl                                                                         \
     git                                                                          \
     golang                                                                       \
     openssh-client                                                               \
@@ -139,11 +140,11 @@ WORKDIR /go/src/github.com/controlplaneio/simulator-standalone/
 USER root
 RUN chown -R ${build_user}:${build_user} /go/src/github.com/controlplaneio/simulator-standalone/
 
-RUN go get honnef.co/go/tools/cmd/staticcheck
-USER ${build_user}
+# We're using sh not bash at this point
+# hadolint ignore=DL4006
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b /usr/local/bin v1.22.2
 
-RUN mkdir /home/${build_user}/go/bin
-ENV PATH=${PATH}:/home/${build_user}/go/bin
+USER ${build_user}
 
 # Golang build and test
 WORKDIR /go/src/github.com/controlplaneio/simulator-standalone

--- a/Makefile
+++ b/Makefile
@@ -111,13 +111,13 @@ docker-test: validate-reqs docker-build ## Run the tests
 # -- SIMULATOR CLI
 .PHONY: dep
 dep: ## Install dependencies for other targets
+	mkdir -p ~/go/bin
 	$(GO) mod download
-	$(GO) get honnef.co/go/tools/cmd/staticcheck
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ~/go/bin v1.22.2
 
 .PHONY: static-analysis
 static-analysis: dep
-	$(GO) vet
-	staticcheck $(PKG)
+	golangci-lint run --new
 
 .PHONY: build
 build: static-analysis ## Run golang build for the CLI program

--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ dep: ## Install dependencies for other targets
 
 .PHONY: static-analysis
 static-analysis: dep
-	golangci-lint run --new
+	golangci-lint run
 
 .PHONY: build
 build: static-analysis ## Run golang build for the CLI program

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -39,7 +39,12 @@ func newConfigCommand() *cobra.Command {
 		logger.Fatalf("can't re-initialize zap logger: %v", err)
 	}
 
-	defer logger.Sync()
+	defer func() {
+		if err := logger.Sync(); err != nil {
+			panic(err)
+		}
+	}()
+
 	cmd.AddCommand(newConfigGetCommand(logger))
 
 	return cmd

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -15,7 +15,12 @@ import (
 func saveBucketConfig(logger *zap.SugaredLogger, bucket string) {
 	logger.Info("Saving state bucket name to config")
 	viper.Set("state-bucket", bucket)
-	viper.WriteConfig()
+	if err := viper.WriteConfig(); err != nil {
+		// TODO(rem): better messaging for the user - this is a first step
+		// to fix the linting errors - the behaviour is better than before
+		// at least we print a stackdump now
+		panic(err)
+	}
 }
 
 func newInitCommand() *cobra.Command {
@@ -29,7 +34,11 @@ func newInitCommand() *cobra.Command {
 			if err != nil {
 				logger.Fatalf("Can't re-initialize zap logger: %v", err)
 			}
-			defer logger.Sync()
+			defer func() {
+				if err := logger.Sync(); err != nil {
+					panic(err)
+				}
+			}()
 
 			if bucket == "" {
 				logger.Info("No state bucket name found in config or on commandline arguments")
@@ -43,7 +52,6 @@ func newInitCommand() *cobra.Command {
 				}
 
 				bucket = strings.TrimSpace(bucket)
-
 
 				logger.Infof("Creating s3 bucket %s for terraform remote state\n", bucket)
 				if err = simulator.CreateRemoteStateBucket(logger, bucket); err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,7 +20,7 @@ debugging Kubernetes
 `,
 }
 
-var logger *zap.SugaredLogger
+var logger *zap.SugaredLogger //nolint:deadcode,unused
 
 func newCmdRoot() *cobra.Command {
 	rootCmd.PersistentFlags().StringVarP(&cfgFile, "config-file", "c", "", "Path to the simulator config file")
@@ -34,27 +34,42 @@ func newCmdRoot() *cobra.Command {
 	rootCmd.AddCommand(newVersionCommand())
 	rootCmd.AddCommand(newCompletionCmd())
 
+	// NOTE the panics here are needed - if these calls fail we cannot recover
+	// and the cause is most likely programmer error
 	rootCmd.PersistentFlags().StringP("state-bucket", "b", "",
 		"The name of the s3 bucket to use for remote-state.  Must be globally unique")
-	rootCmd.MarkFlagRequired("state-bucket")
-	viper.BindPFlag("state-bucket", rootCmd.PersistentFlags().Lookup("state-bucket"))
+	if err := rootCmd.MarkFlagRequired("state-bucket"); err != nil {
+		panic(err)
+	}
+
+	if err := viper.BindPFlag("state-bucket", rootCmd.PersistentFlags().Lookup("state-bucket")); err != nil {
+		panic(err)
+	}
 
 	rootCmd.PersistentFlags().StringP("loglevel", "l", "info", "Level of detail in output logging")
-	viper.BindPFlag("loglevel", rootCmd.PersistentFlags().Lookup("loglevel"))
+	if err := viper.BindPFlag("loglevel", rootCmd.PersistentFlags().Lookup("loglevel")); err != nil {
+		panic(err)
+	}
 
 	rootCmd.PersistentFlags().StringP("tf-dir", "t", "./terraform/deployments/AWS",
 		"Path to a directory containing the infrastructure scripts")
-	viper.BindPFlag("tf-dir", rootCmd.PersistentFlags().Lookup("tf-dir"))
+	if err := viper.BindPFlag("tf-dir", rootCmd.PersistentFlags().Lookup("tf-dir")); err != nil {
+		panic(err)
+	}
 
 	rootCmd.PersistentFlags().StringP("attack-container-tag", "a", "latest",
 		"The attack container tag to pull on the bastion")
-	viper.BindPFlag("attack-container-tag", rootCmd.PersistentFlags().Lookup("attack-container-tag"))
+	if err := viper.BindPFlag("attack-container-tag", rootCmd.PersistentFlags().Lookup("attack-container-tag")); err != nil {
+		panic(err)
+	}
 
 	// TODO: (rem) this is also used to locate the perturb.sh script which may be
 	// subsumed by this app
 	rootCmd.PersistentFlags().StringP("scenarios-dir", "s", "./simulation-scripts",
 		"Path to a directory containing a scenario manifest")
-	viper.BindPFlag("scenarios-dir", rootCmd.PersistentFlags().Lookup("scenarios-dir"))
+	if err := viper.BindPFlag("scenarios-dir", rootCmd.PersistentFlags().Lookup("scenarios-dir")); err != nil {
+		panic(err)
+	}
 
 	return rootCmd
 }
@@ -96,7 +111,9 @@ To configure your Bash shell to load completions for each session add to your ba
 . <(simulator completion)
 `,
 		Run: func(cmd *cobra.Command, args []string) {
-			rootCmd.GenBashCompletion(os.Stdout)
+			if err := rootCmd.GenBashCompletion(os.Stdout); err != nil {
+				panic(err)
+			}
 		},
 	}
 	return cmd

--- a/cmd/scenario.go
+++ b/cmd/scenario.go
@@ -1,13 +1,13 @@
 package cmd
 
 import (
+	"fmt"
 	"github.com/controlplaneio/simulator-standalone/pkg/scenario"
 	"github.com/controlplaneio/simulator-standalone/pkg/simulator"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 	"strings"
-	"fmt"
 )
 
 func newScenarioListCommand(logger *zap.SugaredLogger) *cobra.Command {
@@ -77,7 +77,11 @@ func newScenarioCommand() *cobra.Command {
 	if err != nil {
 		logger.Fatalf("can't re-initialize zap logger: %v", err)
 	}
-	defer logger.Sync()
+	defer func() {
+		if err := logger.Sync(); err != nil {
+			panic(err)
+		}
+	}()
 
 	cmd.AddCommand(newScenarioListCommand(logger))
 	cmd.AddCommand(newScenarioLaunchCommand(logger))

--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -74,7 +74,11 @@ func newSSHCommand() *cobra.Command {
 	if err != nil {
 		logger.Fatalf("can't re-initialize zap logger: %v", err)
 	}
-	defer logger.Sync()
+	defer func() {
+		if err := logger.Sync(); err != nil {
+			panic(err)
+		}
+	}()
 
 	cmd.AddCommand(newSSHConfigCommand(logger))
 	cmd.AddCommand(newSSHAttackCommand(logger))

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -21,7 +21,11 @@ func newVersionCommand() *cobra.Command {
 			if err != nil {
 				logger.Fatalf("Can't re-initialize zap logger: %v", err)
 			}
-			defer logger.Sync()
+			defer func() {
+				if err := logger.Sync(); err != nil {
+					panic(err)
+				}
+			}()
 
 			logger.Infof("version %s\n", version)
 			logger.Infof("git commit %s\n", commit)

--- a/go.sum
+++ b/go.sum
@@ -39,6 +39,7 @@ github.com/cosiner/argv v0.0.1/go.mod h1:p/NrK5tF6ICIly4qwEDsf6VDirFiWWz0FenfYBw
 github.com/cpuguy83/go-md2man v1.0.8/go.mod h1:N6JayAiVKtlHSnuTCeuLSQVs75hb8q+dYQLjr7cDsKY=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davidrjenni/reftools v0.0.0-20190411195930-981bbac422f8/go.mod h1:0qWLWApvobxwtd9/A8fS62VkRImuquIgtCv/ye+KnxA=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
@@ -228,6 +229,7 @@ github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/profile v0.0.0-20170413231811-06b906832ed0/go.mod h1:hJw3o1OdXxsrSjjVksARp5W95eeEaEfptyVZyv6JUPA=
 github.com/pkg/profile v1.3.0/go.mod h1:hJw3o1OdXxsrSjjVksARp5W95eeEaEfptyVZyv6JUPA=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDft0ttaMvbicHlPoso=
@@ -297,6 +299,7 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v1.2.1/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/timakin/bodyclose v0.0.0-20190407043127-4a873e97b2bb/go.mod h1:Qimiffbc6q9tBWlVV6x0P9sat/ao1xEkREYPPj9hphk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/pkg/scenario/scenario.go
+++ b/pkg/scenario/scenario.go
@@ -18,7 +18,7 @@ type Scenario struct {
 	// A Difficulty level for this scenario for use in user interfaces
 	Difficulty string `yaml:"difficulty"`
 	// A short description of the scenario to be used in the user interfaces
-	Description string `yaml: "description"`
+	Description string `yaml:"description"`
 }
 
 // Validate a scenario relative to its manifest
@@ -35,7 +35,7 @@ func (s *Scenario) Validate(manifestPath string) error {
 			"Error stating %s for scenario %s in %s", s.Path, s.DisplayName, manifestPath)
 	}
 
-	if stat.IsDir() != true {
+	if !stat.IsDir() {
 		return errors.Errorf(
 			"Scenario %s is not a directory at %s read from %s",
 			s.DisplayName, s.Path, manifestPath)

--- a/pkg/simulator/launch.go
+++ b/pkg/simulator/launch.go
@@ -25,6 +25,9 @@ func Launch(logger *zap.SugaredLogger, tfDir, scenariosDir, bucketName, id, atta
 
 	logger.Debugf("Checking status of infrastructure")
 	tfo, err := Status(logger, tfDir, bucketName, attackTag)
+	if err != nil {
+		return err
+	}
 	if !tfo.IsUsable() {
 		return errors.Errorf("No infrastructure, please run simulator infra create")
 	}

--- a/pkg/simulator/remote_state.go
+++ b/pkg/simulator/remote_state.go
@@ -11,19 +11,20 @@ import (
 // CreateRemoteStateBucket initialises a remote-state bucket
 func CreateRemoteStateBucket(logger *zap.SugaredLogger, bucket string) error {
 	sess, err := session.NewSession(&aws.Config{})
+	if err != nil {
+		return err
+	}
 
 	svc := s3.New(sess)
 
-	_, err = svc.CreateBucket(&s3.CreateBucketInput{Bucket: aws.String(bucket)})
-	if err != nil {
+	if _, err := svc.CreateBucket(&s3.CreateBucketInput{Bucket: aws.String(bucket)}); err != nil {
 		return errors.Wrapf(err, "Unable to create bucket %q", bucket)
 	}
 
 	logger.Infof("Waiting for bucket %q to be created...", bucket)
-	err = svc.WaitUntilBucketExists(&s3.HeadBucketInput{
+	if err := svc.WaitUntilBucketExists(&s3.HeadBucketInput{
 		Bucket: aws.String(bucket),
-	})
-	if err != nil {
+	}); err != nil {
 		return errors.Wrapf(err, "Error occurred while waiting for bucket to be created, %v", bucket)
 	}
 

--- a/pkg/simulator/ssh.go
+++ b/pkg/simulator/ssh.go
@@ -45,6 +45,5 @@ func Attack(logger *zap.SugaredLogger, tfDir, bucketName, attackTag string) erro
 	}
 
 	logger.Infof("Connecting to", bastion)
-	ssh.SSH(bastion)
-	return nil
+	return ssh.SSH(bastion)
 }

--- a/pkg/simulator/terraform_output.go
+++ b/pkg/simulator/terraform_output.go
@@ -61,9 +61,12 @@ type SSHConfig struct {
 // ToSSHConfig produces the SSH config
 func (tfo *TerraformOutput) ToSSHConfig() (*string, error) {
 	bastionConfigTmpl, err := template.New("bastion-ssh-config").Parse(bastionConfigTmplSrc)
-	k8sConfigTmpl, err := template.New("k8s-ssh-config").Parse(k8sConfigTmplSrc)
 	if err != nil {
 		return nil, errors.Wrap(err, "Error parsing ssh config template")
+	}
+	k8sConfigTmpl, err := template.New("k8s-ssh-config").Parse(k8sConfigTmplSrc)
+	if err != nil {
+		return nil, errors.Wrap(err, "Error parsing k8s config template")
 	}
 
 	var buf bytes.Buffer
@@ -107,7 +110,7 @@ func (tfo *TerraformOutput) ToSSHConfig() (*string, error) {
 		}
 	}
 
-	var output = string(buf.Bytes())
+	var output = buf.String()
 	return &output, nil
 }
 

--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -10,11 +10,6 @@ import (
 	"golang.org/x/crypto/ssh/terminal"
 	"net"
 	"os"
-	"time"
-)
-
-const (
-	timeout = 10 * time.Minute
 )
 
 // GetAuthMethods tries to contact ssh-agent to get the AuthMethods and falls
@@ -131,7 +126,12 @@ func StartInteractiveSSHShell(sshConfig *ssh.ClientConfig, network string, host 
 		if err != nil {
 			return errors.Wrap(err, "Error setting stdin terminal to raw mode")
 		}
-		defer terminal.Restore(fileDescriptor, originalState)
+		defer func() {
+			if err := terminal.Restore(fileDescriptor, originalState); err != nil {
+				// Something really bad happened
+				panic(err)
+			}
+		}()
 	}
 
 	if err = setupPty(fileDescriptor, session); err != nil {

--- a/pkg/util/run.go
+++ b/pkg/util/run.go
@@ -49,8 +49,12 @@ func Run(wd string, env []string, cmd string, args ...string) (*string, error) {
 		return nil, errors.Wrapf(err, "Error starting child process %s", cmd)
 	}
 
-	io.Copy(os.Stdout, tee)
-	io.Copy(os.Stderr, childErr)
+	if _, err = io.Copy(os.Stdout, tee); err != nil {
+		return nil, err
+	}
+	if _, err = io.Copy(os.Stderr, childErr); err != nil {
+		return nil, err
+	}
 
 	err = child.Wait()
 	// TODO: (rem) make this parameterisable?
@@ -58,7 +62,7 @@ func Run(wd string, env []string, cmd string, args ...string) (*string, error) {
 		return nil, errors.Wrapf(err, "Error waiting for child process %s", cmd)
 	}
 
-	out := string(buf.Bytes())
+	out := buf.String()
 	return &out, nil
 }
 
@@ -84,12 +88,12 @@ func RunSilently(wd string, env []string, cmd string, args ...string) (*string, 
 	// TODO: (rem) make this parameterisable?
 	if err != nil && err.Error() != "exit status 127" {
 		//Debug("Error waiting for child process", err)
-		childErr := string(errBuf.Bytes())
+		childErr := errBuf.String()
 		return nil, &childErr, err
 	}
 
-	childErr := string(errBuf.Bytes())
-	childOut := string(outBuf.Bytes())
+	childErr := errBuf.String()
+	childOut := outBuf.String()
 
 	return &childOut, &childErr, nil
 }

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -122,8 +122,6 @@ func MustRemove(path string) {
 	if err != nil {
 		panic(err)
 	}
-
-	return
 }
 
 // EnsureFile checks a file exists and writes the supplied contents if not.

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -58,6 +58,7 @@ func Test_ExpandTilde(t *testing.T) {
 
 	// Call ExpandTilde again to exercise the cache
 	p2, err := util.ExpandTilde("~/.")
+	assert.Nil(t, err, "Got an error resolving tilde")
 	assert.Equal(t, *p, *p2, "Cached version differed")
 
 	p3, err := util.ExpandTilde("fail")


### PR DESCRIPTION
This pull request changes the static analysis to use golangci-lint which is 5x faster than using the tools separately and adds a lot more checks and fewer false positives.

I have fixed all the existing problems as  separate commit: **I had to fix a lot of missing error handling so please pay close attention to that commit**

This partially fixes #149 but more investigation is needed to investigate why module downloading has slowed considerably