### PR TITLE
fix: pertub logging for scenario output

### DIFF
--- a/simulation-scripts/perturb.sh
+++ b/simulation-scripts/perturb.sh
@@ -512,12 +512,11 @@ cat_script_to_run() {
 run_file_on_host() {
   local FILE="${1}"
   local HOST="${2}"
-  #shellcheck disable=SC2094
+  touch "${TMP_DIR}/perturb-script-file-${HOST}.log"
+  cat_script_to_run "${FILE}" >> "${TMP_DIR}/perturb-script-file-${HOST}.log"
+  exec {FD}>>"${TMP_DIR}/perturb-script-file-${HOST}.log"
+  BASH_XTRACEFD=$FD
   (
-    touch "${TMP_DIR}/perturb-script-file-${HOST}.log"
-    cat_script_to_run "${FILE}" >> "${TMP_DIR}/perturb-script-file-${HOST}.log"
-    exec {FD}>>"${TMP_DIR}/perturb-script-file-${HOST}.log"
-    BASH_XTRACEFD=$FD
     set -x
     cat_script_to_run "${FILE}"
   ) | run_ssh "${HOST}" >> "${TMP_DIR}/perturb-script-file-${HOST}.log" 2>&1 && \

--- a/simulation-scripts/perturb.sh
+++ b/simulation-scripts/perturb.sh
@@ -472,20 +472,20 @@ run_cleanup() {
   fi
 
   for FILE_TO_RUN in ${SCRIPTS_TO_RUN}; do
-    get_file_to_run "${FILE_TO_RUN}" | run_ssh "$(get_master)" || true
-    get_file_to_run "${FILE_TO_RUN}" | run_ssh "$(get_node 1)" || true
-    get_file_to_run "${FILE_TO_RUN}" | run_ssh "$(get_node 2)" || true
+    cat_script_to_run "${FILE_TO_RUN}" | run_ssh "$(get_master)" || true
+    cat_script_to_run "${FILE_TO_RUN}" | run_ssh "$(get_node 1)" || true
+    cat_script_to_run "${FILE_TO_RUN}" | run_ssh "$(get_node 2)" || true
   done
 
   # reboot master or workers if required
 
   if [[ -f "${SCENARIO_DIR}/reboot-master.do" ]]; then
-    get_file_to_run "${REBOOT_SCRIPT}" | run_ssh "$(get_master)" || true
+    cat_script_to_run "${REBOOT_SCRIPT}" | run_ssh "$(get_master)" || true
   fi
 
   if [[ -f "${SCENARIO_DIR}/reboot-workers.do" ]]; then
-    get_file_to_run "${REBOOT_SCRIPT}" | run_ssh "$(get_node 1)" || true
-    get_file_to_run "${REBOOT_SCRIPT}" | run_ssh "$(get_node 2)" || true
+    cat_script_to_run "${REBOOT_SCRIPT}" | run_ssh "$(get_node 1)" || true
+    cat_script_to_run "${REBOOT_SCRIPT}" | run_ssh "$(get_node 2)" || true
   fi
 }
 
@@ -499,7 +499,7 @@ run_ssh() {
     root@"${@}"
 }
 
-get_file_to_run() {
+cat_script_to_run() {
   local FILE="${1}"
   if [[ "${IS_DRY_RUN:-}" == 1 ]]; then
     cat "${FILE}" >&2
@@ -515,11 +515,11 @@ run_file_on_host() {
   #shellcheck disable=SC2094
   (
     touch "${TMP_DIR}/perturb-script-file-${HOST}.log"
-    get_file_to_run "${FILE}" >> "${TMP_DIR}/perturb-script-file-${HOST}.log"
+    cat_script_to_run "${FILE}" >> "${TMP_DIR}/perturb-script-file-${HOST}.log"
     exec {FD}>>"${TMP_DIR}/perturb-script-file-${HOST}.log"
     BASH_XTRACEFD=$FD
     set -x
-    get_file_to_run "${FILE}"
+    cat_script_to_run "${FILE}"
   ) | run_ssh "${HOST}" >> "${TMP_DIR}/perturb-script-file-${HOST}.log" 2>&1 && \
   unset BASH_XTRACEFD
   exec {FD}>&-

--- a/simulation-scripts/perturb.sh
+++ b/simulation-scripts/perturb.sh
@@ -516,12 +516,13 @@ run_file_on_host() {
   (
     touch "${TMP_DIR}/perturb-script-file-${HOST}.log"
     get_file_to_run "${FILE}" >> "${TMP_DIR}/perturb-script-file-${HOST}.log"
-    exec 19>>"${TMP_DIR}/perturb-script-file-${HOST}.log"
-    BASH_XTRACEFD=19
+    exec {FD}>>"${TMP_DIR}/perturb-script-file-${HOST}.log"
+    BASH_XTRACEFD=$FD
     set -x
     get_file_to_run "${FILE}"
   ) | run_ssh "${HOST}" >> "${TMP_DIR}/perturb-script-file-${HOST}.log" 2>&1 && \
   unset BASH_XTRACEFD
+  exec {FD}>&-
 }
 
 get_master() {

--- a/simulation-scripts/perturb.sh
+++ b/simulation-scripts/perturb.sh
@@ -133,6 +133,8 @@ run_scenario() {
   get_pods
 
   copy_challenge_and_tasks "${SCENARIO_DIR}"
+
+  rm "${TMP_DIR}"/perturb-script-file-*
 }
 
 container_statuses() {
@@ -513,12 +515,12 @@ run_file_on_host() {
   #shellcheck disable=SC2094
   (
     touch "${TMP_DIR}/perturb-script-file-${HOST}.log"
+    get_file_to_run "${FILE}" >> "${TMP_DIR}/perturb-script-file-${HOST}.log"
     exec 19>>"${TMP_DIR}/perturb-script-file-${HOST}.log"
     BASH_XTRACEFD=19
     set -x
-    get_file_to_run "${FILE}" >> "${TMP_DIR}/perturb-script-file-${HOST}.log" 2>&1
+    get_file_to_run "${FILE}"
   ) | run_ssh "${HOST}" >> "${TMP_DIR}/perturb-script-file-${HOST}.log" 2>&1 && \
-  rm "${TMP_DIR}/perturb-script-file-${HOST}.log"
   unset BASH_XTRACEFD
 }
 


### PR DESCRIPTION
Perturb is currently redirecting the scripts to run on the remote hosts to logs rather than ssh. This change fixes that and moves log cleanup to be the last thing perturb does.
