### PR TITLE
fix(perturb): clean up .kubesim files correctly

### DIFF
--- a/simulation-scripts/perturb.sh
+++ b/simulation-scripts/perturb.sh
@@ -140,7 +140,7 @@ run_scenario() {
 cleanup() {
   shopt -u nullglob
   if ls "${TMP_DIR}"/perturb-script-file-* > /dev/null 2>&1; then
-  rm "${TMP_DIR}"/perturb-script-file-*
+    rm "${TMP_DIR}"/perturb-script-file-*
   fi
   if ls "${TMP_DIR}"/docker-* > /dev/null 2>&1; then
     rm "${TMP_DIR}"/docker-*

--- a/simulation-scripts/perturb.sh
+++ b/simulation-scripts/perturb.sh
@@ -134,7 +134,18 @@ run_scenario() {
 
   copy_challenge_and_tasks "${SCENARIO_DIR}"
 
+  cleanup
+}
+
+cleanup() {
+  shopt -u nullglob
+  if ls "${TMP_DIR}"/perturb-script-file-* > /dev/null 2>&1; then
   rm "${TMP_DIR}"/perturb-script-file-*
+  fi
+  if ls "${TMP_DIR}"/docker-* > /dev/null 2>&1; then
+    rm "${TMP_DIR}"/docker-*
+  fi
+  shopt -s nullglob
 }
 
 container_statuses() {

--- a/simulation-scripts/perturb.sh
+++ b/simulation-scripts/perturb.sh
@@ -139,10 +139,10 @@ run_scenario() {
 
 cleanup() {
   shopt -u nullglob
-  if ls "${TMP_DIR}"/perturb-script-file-* > /dev/null 2>&1; then
+  if [[ -n $(compgen -G ${TMP_DIR}/perturb-script-file-*) ]]; then
     rm "${TMP_DIR}"/perturb-script-file-*
   fi
-  if ls "${TMP_DIR}"/docker-* > /dev/null 2>&1; then
+  if [[ -n $(compgen -G ${TMP_DIR}/docker-*) ]]; then
     rm "${TMP_DIR}"/docker-*
   fi
   shopt -s nullglob


### PR DESCRIPTION
At the moment perturb will error if it tries to clean up script log files that do not exist. This is a bug as not all scenarios use scripts so will not produce these files. This PR fixes that behaviour.
