### PR TITLE
Pod starting point

### DIFF
--- a/attack/scripts/bashrc
+++ b/attack/scripts/bashrc
@@ -141,7 +141,10 @@ starting_point() {
 
   #Determine if mode is pod.
   if [[ "$MODE" == "pod" ]]; then
-    echo "Starting point: POD - Not yet implemented. Please use 'ssh_internal' and then 'kubectl exec ...' to start in the relevant pod."
+    POD_NAME="$(echo "${task_json}" | jq -r --arg TASK_NO "${task_no}" '.tasks | .[$TASK_NO] | .startingPoint.podName')"
+    POD_NS="$(echo "${task_json}" | jq -r --arg TASK_NO "${task_no}" '.tasks | .[$TASK_NO] | .startingPoint.podNamespace')"
+    # shellcheck disable=SC2029
+    ssh -tt "$INTERNAL_HOST_IP" "kubectl exec -it -n ${POD_NS} ${POD_NAME} bash"
     return
   fi
 

--- a/attack/scripts/bashrc
+++ b/attack/scripts/bashrc
@@ -111,9 +111,9 @@ starting_point() {
     KUBECTL_ACCESS="$(echo "${task_json}" | jq -r --arg TASK_NO "${task_no}" '.tasks | .[$TASK_NO] | .startingPoint.kubectlAccess')"
 
     if [[ "$KUBECTL_ACCESS" == "false" ]]; then
-      ssh "$INTERNAL_HOST_IP" 'ls -d ~/.kube >/dev/null 2>&1 && mv ~/.kube /var/local/'
+      ssh "$INTERNAL_HOST_IP" 'compgen -d ~/.kube >/dev/null 2>&1 && mv ~/.kube /var/local/'
     else
-      ssh "$INTERNAL_HOST_IP" 'ls -d ~/.kube >/dev/null 2>&1 || mv /var/local/.kube ~/'
+      ssh "$INTERNAL_HOST_IP" 'compgen -d ~/.kube >/dev/null 2>&1 || mv /var/local/.kube ~/'
     fi
 
     ssh_internal
@@ -123,12 +123,12 @@ starting_point() {
     NODE_TYPE="$(echo "${task_json}" | jq -r --arg TASK_NO "${task_no}" '.tasks | .[$TASK_NO] | .startingPoint.nodeId')"
 
     if [[ "$NODE_TYPE" =~ "master" ]]; then
-      NODE_NUMBER="$(echo "$NODE_TYPE" | sed "s/nodeId: 'master-//" | sed "s/'//")"
+      NODE_NUMBER="${NODE_TYPE#'master-'}"
 
       ssh_master "$NODE_NUMBER"
 
     elif [[ "$NODE_TYPE" =~ "node" ]]; then
-      NODE_NUMBER="$(echo "$NODE_TYPE" | sed "s/nodeId: 'node-//" | sed "s/'//")"
+      NODE_NUMBER="${NODE_TYPE#'node-'}"
 
       ssh_node "$NODE_NUMBER"
     else

--- a/attack/scripts/bashrc
+++ b/attack/scripts/bashrc
@@ -104,16 +104,16 @@ starting_point() {
     return 1
   fi
   # Identify the starting point mode
-  MODE="$(echo "${task_json}" | jq -r --arg TASK_NO "${task_no}" '.tasks | .[$TASK_NO] | ."starting-point".mode')"
+  MODE="$(echo "${task_json}" | jq -r --arg TASK_NO "${task_no}" '.tasks | .[$TASK_NO] | .startingPoint.mode')"
 
   #Determine if mode is internal-instance.
   if [[ "$MODE" == "internal-instance" ]]; then
-    KUBECTL_ACCESS="$(echo "${task_json}" | jq -r --arg TASK_NO "${task_no}" '.tasks | .[$TASK_NO] | ."starting-point"."kubectl-access"')"
+    KUBECTL_ACCESS="$(echo "${task_json}" | jq -r --arg TASK_NO "${task_no}" '.tasks | .[$TASK_NO] | .startingPoint.kubectlAccess')"
 
     if [[ "$KUBECTL_ACCESS" == "false" ]]; then
-      ssh "$INTERNAL_HOST_IP" mv ~/.kube /var/local/
-    elif [[ ! -d ~/.kube ]]; then
-      ssh "$INTERNAL_HOST_IP" mv /var/local/.kube ~/
+      ssh "$INTERNAL_HOST_IP" 'ls -d ~/.kube >/dev/null 2>&1 && mv ~/.kube /var/local/'
+    else
+      ssh "$INTERNAL_HOST_IP" 'ls -d ~/.kube >/dev/null 2>&1 || mv /var/local/.kube ~/'
     fi
 
     ssh_internal
@@ -122,17 +122,17 @@ starting_point() {
 
   #Determine if mode is node.
   if [[ "$MODE" == "node" ]]; then
-    NODE_TYPE="$(echo "${task_json}" | jq -r --arg TASK_NO "${task_no}" '.tasks | .[$TASK_NO] | ."starting-point"."node-id"')"
+    NODE_TYPE="$(echo "${task_json}" | jq -r --arg TASK_NO "${task_no}" '.tasks | .[$TASK_NO] | .startingPoint.nodeId')"
 
     if [[ "$NODE_TYPE" =~ "master" ]]; then
-      NODE_NUMBER="$(echo "$NODE_TYPE" | sed "s/node-id: 'master-//" | sed "s/'//")"
+      NODE_NUMBER="$(echo "$NODE_TYPE" | sed "s/nodeId: 'master-//" | sed "s/'//")"
 
       ssh_master "$NODE_NUMBER"
       return
     fi
 
     if [[ "$NODE_TYPE" =~ "node" ]]; then
-      NODE_NUMBER="$(echo "$NODE_TYPE" | sed "s/node-id: 'node-//" | sed "s/'//")"
+      NODE_NUMBER="$(echo "$NODE_TYPE" | sed "s/nodeId: 'node-//" | sed "s/'//")"
 
       ssh_node "$NODE_NUMBER"
       return
@@ -225,7 +225,7 @@ welcome() {
   info ' '
   info "You have found a private kubernetes cluster."
   info ' '
-  info "There are ${BOLD}${#MASTER_NODES[@]}${NORMAL} master and ${BOLD}${#WORKER_NODES[@]}${NORMAL} nodes in the cluster."
+  info "There are ${BOLD}${#MASTER_NODES[@]}${NORMAL} ${COLOUR_BLUE}master and ${BOLD}${#WORKER_NODES[@]}${NORMAL} ${COLOUR_BLUE}nodes in the cluster."
   info ' '
   info "If you want to begin to work on the scenario from its starting point:"
   info ' '

--- a/attack/scripts/bashrc
+++ b/attack/scripts/bashrc
@@ -111,9 +111,9 @@ starting_point() {
     KUBECTL_ACCESS="$(echo "${task_json}" | jq -r --arg TASK_NO "${task_no}" '.tasks | .[$TASK_NO] | .startingPoint.kubectlAccess')"
 
     if [[ "$KUBECTL_ACCESS" == "false" ]]; then
-      ssh "$INTERNAL_HOST_IP" 'compgen -d ~/.kube >/dev/null 2>&1 && mv ~/.kube /var/local/'
+      ssh "$INTERNAL_HOST_IP" '[[ $(compgen -d ~/.kube) ]] && mv ~/.kube /var/local/'
     else
-      ssh "$INTERNAL_HOST_IP" 'compgen -d ~/.kube >/dev/null 2>&1 || mv /var/local/.kube ~/'
+      ssh "$INTERNAL_HOST_IP" '[[ $(compgen -d ~/.kube) ]] || mv /var/local/.kube ~/'
     fi
 
     ssh_internal

--- a/attack/scripts/bashrc
+++ b/attack/scripts/bashrc
@@ -117,44 +117,46 @@ starting_point() {
     fi
 
     ssh_internal
-    return
-  fi
 
   #Determine if mode is node.
-  if [[ "$MODE" == "node" ]]; then
+  elif [[ "$MODE" == "node" ]]; then
     NODE_TYPE="$(echo "${task_json}" | jq -r --arg TASK_NO "${task_no}" '.tasks | .[$TASK_NO] | .startingPoint.nodeId')"
 
     if [[ "$NODE_TYPE" =~ "master" ]]; then
       NODE_NUMBER="$(echo "$NODE_TYPE" | sed "s/nodeId: 'master-//" | sed "s/'//")"
 
       ssh_master "$NODE_NUMBER"
-      return
-    fi
 
-    if [[ "$NODE_TYPE" =~ "node" ]]; then
+    elif [[ "$NODE_TYPE" =~ "node" ]]; then
       NODE_NUMBER="$(echo "$NODE_TYPE" | sed "s/nodeId: 'node-//" | sed "s/'//")"
 
       ssh_node "$NODE_NUMBER"
-      return
+    else
+      warning "An unrecognised node type has been selected. Please report this to the scenario author."
+      info "Please use the ssh helper 'ssh_node ...' to start the task."
+      exit 3
     fi
-  fi
 
   #Determine if mode is pod.
-  if [[ "$MODE" == "pod" ]]; then
+  elif [[ "$MODE" == "pod" ]]; then
     POD_NAME="$(echo "${task_json}" | jq -r --arg TASK_NO "${task_no}" '.tasks | .[$TASK_NO] | .startingPoint.podName')"
     POD_NS="$(echo "${task_json}" | jq -r --arg TASK_NO "${task_no}" '.tasks | .[$TASK_NO] | .startingPoint.podNamespace')"
     # shellcheck disable=SC2029
     ssh -tt "$INTERNAL_HOST_IP" "kubectl exec -it -n ${POD_NS} ${POD_NAME} bash"
-    return
-  fi
+
+  #Determine if mode is attack.
+  elif [[ "$MODE" == "attack" ]]; then
+    echo "The starting point for this task is in this container. Please use the ssh helpers 'ssh_internal,' 'ssh_master' and 'ssh_node ...' to start the task."
 
   #Determine if mode is null.
-  if [[ "$MODE" == "null" ]]; then
-    echo "No Starting point has been configured for this task. Please use the ssh helpers 'ssh_internal,' 'ssh_master' and 'ssh_node ...' to start the task."
-    return
-  fi
+  elif [[ "$MODE" == "null" ]]; then
+    echo "No starting point has been configured for this task. Please use the ssh helpers 'ssh_internal,' 'ssh_master' and 'ssh_node ...' to start the task."
 
-  echo "The scenario configuration file is not following the expected format."
+  else
+    warning "An unrecognised starting point has been selected. Please report this to the scenario author."
+    info "Please use the ssh helpers 'ssh_internal,' 'ssh_master' and 'ssh_node ...' to start the task."
+    exit 4
+  fi
 }
 readonly -f starting_point
 export -f starting_point

--- a/simulation-scripts/perturb.sh
+++ b/simulation-scripts/perturb.sh
@@ -98,7 +98,7 @@ main() {
     if [[ "${IS_FORCE}" != 1 ]]; then
       if ! is_special_scenario; then
         warning "Scenario ${FOUND_SCENARIO} already deployed"
-        #exit 103
+        exit 103
       fi
     fi
   fi

--- a/simulation-scripts/perturb.sh
+++ b/simulation-scripts/perturb.sh
@@ -98,7 +98,7 @@ main() {
     if [[ "${IS_FORCE}" != 1 ]]; then
       if ! is_special_scenario; then
         warning "Scenario ${FOUND_SCENARIO} already deployed"
-        exit 103
+        #exit 103
       fi
     fi
   fi
@@ -268,6 +268,8 @@ copy_challenge_and_tasks() {
 
   if grep 'mode\:\ pod' tasks.yaml >/dev/null; then
     template_tasks
+  else
+    cp tasks.yaml "${tmptasks}"
   fi
 
   info "Copying challenge.txt from ${SCENARIO_DIR} to ${BASTION_HOST}"

--- a/simulation-scripts/scenario/container-ambush/tasks.yaml
+++ b/simulation-scripts/scenario/container-ambush/tasks.yaml
@@ -2,7 +2,7 @@ kind: cp.simulator/scenario:1.0.0
 objective: Get postgres password.
 startingPoint:
   mode: pod
-  podName: ""
+  podName: "jenkins"
   podNamespace: container-ambush
 tasks:
   "1":
@@ -16,7 +16,7 @@ tasks:
     sortOrder: 1
     startingPoint:
       mode: pod
-      podName: ""
+      podName: "jenkins"
       podNamespace: container-ambush
     summary: "There was a docker socket mounted into the container. Using it we could query Docker to find the value of an environment variable in another container."
   "2":

--- a/simulation-scripts/scenario/container-ambush/tasks.yaml
+++ b/simulation-scripts/scenario/container-ambush/tasks.yaml
@@ -1,30 +1,30 @@
 kind: cp.simulator/scenario:1.0.0
 objective: Get postgres password.
-starting-point:
+startingPoint:
   mode: pod
-  pod-name: ""
-  pod-namespace: container-ambush
+  podName: ""
+  podNamespace: container-ambush
 tasks:
   "1":
     hints:
-    - text: What mounts do we have in this container?
-    - text: Looks like the docker socket is mounted at /var/run/docker.sock.
-    - text: I wonder if i can install Docker in here to use that socket?
-    - text: Let's inspect the other containers running on this host.
-    - text: The nginx container seems to be the one we're looking for.
-    - text: That environment variable looks like a secret!
-    sort-order: 1
-    starting-point:
+      - text: What mounts do we have in this container?
+      - text: Looks like the docker socket is mounted at /var/run/docker.sock.
+      - text: I wonder if i can install Docker in here to use that socket?
+      - text: Let's inspect the other containers running on this host.
+      - text: The nginx container seems to be the one we're looking for.
+      - text: That environment variable looks like a secret!
+    sortOrder: 1
+    startingPoint:
       mode: pod
-      pod-name: ""
-      pod-namespace: container-ambush
+      podName: ""
+      podNamespace: container-ambush
     summary: "There was a docker socket mounted into the container. Using it we could query Docker to find the value of an environment variable in another container."
   "2":
     hints:
-    - text: How did you access the keys? Can you inject a secret another way?
-    - text: The gold standard way of consuming a secret is as a volume mount.
-    sort-order: 2
-    starting-point:
-      kubectl-access: true
+      - text: How did you access the keys? Can you inject a secret another way?
+      - text: The gold standard way of consuming a secret is as a volume mount.
+    sortOrder: 2
+    startingPoint:
+      kubectlAccess: true
       mode: internal-instance
     summary: "We injected the secret value into the container as an environment variable backed by a kubernetes secret."

--- a/simulation-scripts/scenario/container-defeat-in-detail/tasks.yaml
+++ b/simulation-scripts/scenario/container-defeat-in-detail/tasks.yaml
@@ -1,30 +1,33 @@
 kind: cp.simulator/scenario:1.0.0
-objective: Exec into a container on master with certificates mounted in to exploit
+objective:
+  Exec into a container on master with certificates mounted in to exploit
   etcd.
-starting-point:
-  kubectl-access: true
+startingPoint:
+  kubectlAccess: true
   mode: internal-instance
 tasks:
   "1":
     hints:
-    - text: I should choose which cert-manager pod to start in carefully.
-    - text: One of these seems to be running on a master, that's probably the best
-        place to start.
-    - text: Let's check the mounts in this container.
-    - text: There are some etcd certs here, I think I was given the IP for the etcd
-        cluster earlier.
-    - text: The key I'm after is probably the '/super/secret one'.
-    sort-order: 1
-    starting-point:
-      kubectl-access: true
+      - text: I should choose which cert-manager pod to start in carefully.
+      - text:
+          One of these seems to be running on a master, that's probably the best
+          place to start.
+      - text: Let's check the mounts in this container.
+      - text:
+          There are some etcd certs here, I think I was given the IP for the etcd
+          cluster earlier.
+      - text: The key I'm after is probably the '/super/secret one'.
+    sortOrder: 1
+    startingPoint:
+      kubectlAccess: true
       mode: internal-instance
     summary: "We managed to retrieve a secret value from etcd using some certificates mounted into the container accidentally."
   "2":
     hints:
-    - text: Let's check the node config.
-    - text: The master is missing its taint!
-    sort-order: 2
-    starting-point:
-      kubectl-access: true
+      - text: Let's check the node config.
+      - text: The master is missing its taint!
+    sortOrder: 2
+    startingPoint:
+      kubectlAccess: true
       mode: internal-instance
     summary: "The master node needed its master taint to be reapplied."

--- a/simulation-scripts/scenario/container-phalanx-formation/tasks.yaml
+++ b/simulation-scripts/scenario/container-phalanx-formation/tasks.yaml
@@ -1,19 +1,20 @@
 kind: cp.simulator/scenario:1.0.0
 objective: Find a secret in a log file.
-starting-point:
-  kubectl-access: true
+startingPoint:
+  kubectlAccess: true
   mode: internal-instance
 tasks:
   "1":
     hints:
-    - text: So I need to start in the container-phalanx-formation namespace.
-    - text: Looks like the 'log' container in the app pod is ubuntu. Might be best
-        to start there.
-    - text: Looking at the filesystem, there seems to be a mount at /log.
-    - text: Is there anything in the log file in /log?
-    - text: What happens if I grep that file for a 'password'.
-    sort-order: 1
-    starting-point:
-      kubectl-access: true
+      - text: So I need to start in the container-phalanx-formation namespace.
+      - text:
+          Looks like the 'log' container in the app pod is ubuntu. Might be best
+          to start there.
+      - text: Looking at the filesystem, there seems to be a mount at /log.
+      - text: Is there anything in the log file in /log?
+      - text: What happens if I grep that file for a 'password'.
+    sortOrder: 1
+    startingPoint:
+      kubectlAccess: true
       mode: internal-instance
     summary: "By using our kubectl access we were able to exec into a pod and read sensitive information from a malfunctioning logging mechanism."

--- a/simulation-scripts/scenario/etcd-inverted-wedge/tasks.yaml
+++ b/simulation-scripts/scenario/etcd-inverted-wedge/tasks.yaml
@@ -4,7 +4,7 @@ objective:
   node IP. Fix the leakage.
 startingPoint:
   mode: pod
-  podName: ""
+  podName: "ubuntu"
   podNamespace: etcd-inverted-wedge
 tasks:
   "1":
@@ -24,7 +24,7 @@ tasks:
     sortOrder: 1
     startingPoint:
       mode: pod
-      podName: ""
+      podName: "ubuntu"
       podNamespace: etcd-inverted-wedge
     summary: "Etcd allowed us to connect to it without using certificates."
   "2":

--- a/simulation-scripts/scenario/etcd-inverted-wedge/tasks.yaml
+++ b/simulation-scripts/scenario/etcd-inverted-wedge/tasks.yaml
@@ -1,38 +1,43 @@
 kind: cp.simulator/scenario:1.0.0
-objective: Discover uncertified etcd, reach it with only network access and master
+objective:
+  Discover uncertified etcd, reach it with only network access and master
   node IP. Fix the leakage.
-starting-point:
+startingPoint:
   mode: pod
-  pod-name: ""
-  pod-namespace: etcd-inverted-wedge
+  podName: ""
+  podNamespace: etcd-inverted-wedge
 tasks:
   "1":
     hints:
-    - text: Since we know the leak is not from the API Server or Kubelet, could the
-        secrets be leaking directly from etcd?
-    - text: Try to install etcdctl and explore.
-    - text: List etcd endpoints with ```ETCDCTL_API=3 etcdctl --endpoints=https://<K8s
-        master IP>:2379 --insecure-transport=false --insecure-skip-tls-verify get
-        / --prefix --keys-only```
-    - text: Let's see if there's any 'secrets' here.
-    - text: '```ETCDCTL_API=3 etcdctl --endpoints=https://<K8s master IP>:2379 --insecure-transport=false
-        --insecure-skip-tls-verify get /registry/secrets/etcd-inverted-wedge/credentials```'
-    sort-order: 1
-    starting-point:
+      - text:
+          Since we know the leak is not from the API Server or Kubelet, could the
+          secrets be leaking directly from etcd?
+      - text: Try to install etcdctl and explore.
+      - text:
+          List etcd endpoints with ```ETCDCTL_API=3 etcdctl --endpoints=https://<K8s
+          master IP>:2379 --insecure-transport=false --insecure-skip-tls-verify get
+          / --prefix --keys-only```
+      - text: Let's see if there's any 'secrets' here.
+      - text:
+          "```ETCDCTL_API=3 etcdctl --endpoints=https://<K8s master IP>:2379 --insecure-transport=false
+          --insecure-skip-tls-verify get /registry/secrets/etcd-inverted-wedge/credentials```"
+    sortOrder: 1
+    startingPoint:
       mode: pod
-      pod-name: ""
-      pod-namespace: etcd-inverted-wedge
+      podName: ""
+      podNamespace: etcd-inverted-wedge
     summary: "Etcd allowed us to connect to it without using certificates."
   "2":
     hints:
-    - text: How could we reach the etcd backend with no certificates?
-    - text: Where does kubeadm keep it's etcd config?
-    - text: One of the configuration options here looks wrong.
-    - text: On the master node in /etc/kubernetes/manifests/etcd.yaml change - --client-cert-auth=false
-        to --client-cert-auth=true
-    sort-order: 2
-    starting-point:
-      as-root: true
+      - text: How could we reach the etcd backend with no certificates?
+      - text: Where does kubeadm keep it's etcd config?
+      - text: One of the configuration options here looks wrong.
+      - text:
+          On the master node in /etc/kubernetes/manifests/etcd.yaml change - --client-cert-auth=false
+          to --client-cert-auth=true
+    sortOrder: 2
+    startingPoint:
+      asRoot: true
       mode: node
-      node-id: master-0
+      nodeId: master-0
     summary: "We re-enabled client certificate authentication in the etcd manifest on the master."

--- a/simulation-scripts/scenario/master-encirclement/tasks.yaml
+++ b/simulation-scripts/scenario/master-encirclement/tasks.yaml
@@ -1,21 +1,23 @@
 kind: cp.simulator/scenario:1.0.0
 objective: Enable MutatingAdmissionWebhook admission controller in the API server.
-starting-point:
-  as-root: true
+startingPoint:
+  asRoot: true
   mode: node
-  node-id: master-0
+  nodeId: master-0
 tasks:
   "1":
     hints:
-    - text: Hmm, the webhook configuration looks good. What other factors could influence
-        the permissions?
-    - text: The webhook deployment also looks like it's working
-    - text: Where does kubeadm keep the master config?
-    - text: Looks like the MutatingAdmissionWebhook admission controller has been
-        disabled. I probably need to enable it.
-    sort-order: 1
-    starting-point:
-      as-root: true
+      - text:
+          Hmm, the webhook configuration looks good. What other factors could influence
+          the permissions?
+      - text: The webhook deployment also looks like it's working
+      - text: Where does kubeadm keep the master config?
+      - text:
+          Looks like the MutatingAdmissionWebhook admission controller has been
+          disabled. I probably need to enable it.
+    sortOrder: 1
+    startingPoint:
+      asRoot: true
       mode: node
-      node-id: master-0
+      nodeId: master-0
     summary: "The Mutating Admission Webhook admission controller was disabled. We re-enabled it in the manifest for the api server."

--- a/simulation-scripts/scenario/master-shell-scrape/tasks.yaml
+++ b/simulation-scripts/scenario/master-shell-scrape/tasks.yaml
@@ -2,7 +2,7 @@ kind: cp.simulator/scenario:1.0.0
 objective: API is enabled on --insecure-bind-address and --insecure-port
 startingPoint:
   mode: pod
-  podName: ""
+  podName: "ubuntu"
   podNamespace: master-shell-scrape
 tasks:
   "1":
@@ -16,7 +16,7 @@ tasks:
     sortOrder: 1
     startingPoint:
       mode: pod
-      podName: ""
+      podName: "ubuntu"
       podNamespace: master-shell-scrape
     summary: "We were able to make privileged api calls to the api server with authenticating."
   "2":

--- a/simulation-scripts/scenario/master-shell-scrape/tasks.yaml
+++ b/simulation-scripts/scenario/master-shell-scrape/tasks.yaml
@@ -1,32 +1,36 @@
 kind: cp.simulator/scenario:1.0.0
 objective: API is enabled on --insecure-bind-address and --insecure-port
-starting-point:
+startingPoint:
   mode: pod
-  pod-name: ""
-  pod-namespace: master-shell-scrape
+  podName: ""
+  podNamespace: master-shell-scrape
 tasks:
   "1":
     hints:
-    - text: Have a look at your environment variables with ```printenv```. Does anything
-        look suspicious?
-    - text: Looks like you may be able to access the Kubernetes API on port 8080.
-        Try curling some of the end-points. You may need to download curl.
-    sort-order: 1
-    starting-point:
+      - text:
+          Have a look at your environment variables with ```printenv```. Does anything
+          look suspicious?
+      - text:
+          Looks like you may be able to access the Kubernetes API on port 8080.
+          Try curling some of the end-points. You may need to download curl.
+    sortOrder: 1
+    startingPoint:
       mode: pod
-      pod-name: ""
-      pod-namespace: master-shell-scrape
+      podName: ""
+      podNamespace: master-shell-scrape
     summary: "We were able to make privileged api calls to the api server with authenticating."
   "2":
     hints:
-    - text: The API appears to be open on the Master node without certification. Have
-        a look at the API configuration and see why that is.
-    - text: --insecure-bind-address and --insecure-port is enabled on the API in the
-        manifest at /etc/kubernetes/manifests/kube-apiserver.yaml. Set the insecure
-        port to 0 and delete the binding.
-    sort-order: 2
-    starting-point:
-      as-root: true
+      - text:
+          The API appears to be open on the Master node without certification. Have
+          a look at the API configuration and see why that is.
+      - text:
+          --insecure-bind-address and --insecure-port is enabled on the API in the
+          manifest at /etc/kubernetes/manifests/kube-apiserver.yaml. Set the insecure
+          port to 0 and delete the binding.
+    sortOrder: 2
+    startingPoint:
+      asRoot: true
       mode: node
-      node-id: master-0
+      nodeId: master-0
     summary: "We disabled the --insecure bind port and address options in the api server manifest."

--- a/simulation-scripts/scenario/network-feint/tasks.yaml
+++ b/simulation-scripts/scenario/network-feint/tasks.yaml
@@ -1,36 +1,37 @@
 kind: cp.simulator/scenario:1.0.0
 objective: Use misconfigured svc to compromise db.
-starting-point:
-  kubectl-access: false
+startingPoint:
+  kubectlAccess: false
   mode: internal-instance
 tasks:
   "1":
     hints:
-    - text: What's returning the empty responses when the NodePort is queried?
-    - text: Many databases are SQL based, could it be one of the popular ones?
-    - text: I wonder what the default username for each SQL database is?
-    - text: One of the devs mentioned a Postgres database they used didn't have a
-        password, could this be it?
-    - text: Hmm, how do I list tables and view the keys in tables again?
-    sort-order: 1
-    starting-point:
-      kubectl-access: false
+      - text: What's returning the empty responses when the NodePort is queried?
+      - text: Many databases are SQL based, could it be one of the popular ones?
+      - text: I wonder what the default username for each SQL database is?
+      - text:
+          One of the devs mentioned a Postgres database they used didn't have a
+          password, could this be it?
+      - text: Hmm, how do I list tables and view the keys in tables again?
+    sortOrder: 1
+    startingPoint:
+      kubectlAccess: false
       mode: internal-instance
     summary: "We used psql to query the application database from outside the cluster. This should not be allowed."
   "2":
     hints:
-    - text: The database shouldn't be talking to the outside world.
-    - text: The labels on this service are interesting.
-    sort-order: 2
-    starting-point:
-      kubectl-access: true
+      - text: The database shouldn't be talking to the outside world.
+      - text: The labels on this service are interesting.
+    sortOrder: 2
+    startingPoint:
+      kubectlAccess: true
       mode: internal-instance
     summary: "The labels on the the frontend service select to many pods. We made the labels more selective to fix the issue."
   "3":
     hints:
-    - text: I wonder if a network policy would help here.
-    sort-order: 3
-    starting-point:
-      kubectl-access: true
+      - text: I wonder if a network policy would help here.
+    sortOrder: 3
+    startingPoint:
+      kubectlAccess: true
       mode: internal-instance
     summary: "We added a network policy to the namespace to prevent all but approved traffic between pods and the outside."

--- a/simulation-scripts/scenario/network-hammer-and-anvil/tasks.yaml
+++ b/simulation-scripts/scenario/network-hammer-and-anvil/tasks.yaml
@@ -2,7 +2,7 @@ kind: cp.simulator/scenario:1.0.0
 objective: Use badly configured database to exfiltrate data.
 startingPoint:
   mode: pod
-  podName: ""
+  podName: "frontend"
   podNamespace: network-hammer-and-anvil
 tasks:
   "1":
@@ -19,7 +19,7 @@ tasks:
     sortOrder: 1
     startingPoint:
       mode: pod
-      podName: ""
+      podName: "frontend"
       podNamespace: network-hammer-and-anvil
     summary: "We SSH'd into a sidecar container of a database pod after finding some credentials in our starting pod. From there we accessed the database directly and through a shared mount to exfiltrate some secret data."
   "2":

--- a/simulation-scripts/scenario/network-hammer-and-anvil/tasks.yaml
+++ b/simulation-scripts/scenario/network-hammer-and-anvil/tasks.yaml
@@ -1,33 +1,34 @@
 kind: cp.simulator/scenario:1.0.0
 objective: Use badly configured database to exfiltrate data.
-starting-point:
+startingPoint:
   mode: pod
-  pod-name: ""
-  pod-namespace: network-hammer-and-anvil
+  podName: ""
+  podNamespace: network-hammer-and-anvil
 tasks:
   "1":
     hints:
-    - text: Is there anything useful in the env vars?
-    - text: Those look like a host and password for a root SSH user!
-    - text: I think Postgres doesn't need a password if you're reaching it from localhost.
-    - text: I can use pg_dump get the data from the database.
-    - text: I wonder if there are any mount points in this container.
-    - text: Is there something there in /backups?
-    - text: I have an IP and SSH key from the welcome text to this challenge, I can
-        'scp' my data to there.
-    sort-order: 1
-    starting-point:
+      - text: Is there anything useful in the env vars?
+      - text: Those look like a host and password for a root SSH user!
+      - text: I think Postgres doesn't need a password if you're reaching it from localhost.
+      - text: I can use pg_dump get the data from the database.
+      - text: I wonder if there are any mount points in this container.
+      - text: Is there something there in /backups?
+      - text:
+          I have an IP and SSH key from the welcome text to this challenge, I can
+          'scp' my data to there.
+    sortOrder: 1
+    startingPoint:
       mode: pod
-      pod-name: ""
-      pod-namespace: network-hammer-and-anvil
+      podName: ""
+      podNamespace: network-hammer-and-anvil
     summary: "We SSH'd into a sidecar container of a database pod after finding some credentials in our starting pod. From there we accessed the database directly and through a shared mount to exfiltrate some secret data."
   "2":
     hints:
-    - text: The database shouldn't need to talk externally.
-    - text: Only the frontend should have access to the database.
-    - text: I wonder if a network policy would help here.
-    sort-order: 2
-    starting-point:
-      kubectl-access: true
+      - text: The database shouldn't need to talk externally.
+      - text: Only the frontend should have access to the database.
+      - text: I wonder if a network policy would help here.
+    sortOrder: 2
+    startingPoint:
+      kubectlAccess: true
       mode: internal-instance
     summary: "We used a network policy to prevent the database from exfiltrating data and preventing SSH into the sidecar container."

--- a/simulation-scripts/scenario/network-hedgehog-defence/challenge.txt
+++ b/simulation-scripts/scenario/network-hedgehog-defence/challenge.txt
@@ -1,7 +1,7 @@
 Scenario: You are performing a postmortem on an attack against your database in the 'network-hedgehog-defence' namespace.
 The 'database' service is only supposed to be reachable from within its namespace, but your audit logs have revealed unusual requests from an unrelated setup pod in the 'default' namespace.
 
-Starting Point: setup pod
+Starting Point: setup pod in the default namespace
 
 Difficulty: Medium
 

--- a/simulation-scripts/scenario/network-hedgehog-defence/tasks.yaml
+++ b/simulation-scripts/scenario/network-hedgehog-defence/tasks.yaml
@@ -2,8 +2,8 @@ kind: cp.simulator/scenario:1.0.0
 objective: Compromised database from outside namespace.
 startingPoint:
   mode: pod
-  podName: ""
-  podNamespace: network-hedgehog-defence
+  podName: "setup"
+  podNamespace: default
 tasks:
   "1":
     hints:
@@ -22,8 +22,8 @@ tasks:
     sortOrder: 1
     startingPoint:
       mode: pod
-      podName: ""
-      podNamespace: network-hedgehog-defence
+      podName: "setup"
+      podNamespace: default
     summary: "Using psql we managed to get some secret data from a pod in another namespace."
   "2":
     hints:

--- a/simulation-scripts/scenario/network-hedgehog-defence/tasks.yaml
+++ b/simulation-scripts/scenario/network-hedgehog-defence/tasks.yaml
@@ -1,33 +1,37 @@
 kind: cp.simulator/scenario:1.0.0
 objective: Compromised database from outside namespace.
-starting-point:
+startingPoint:
   mode: pod
-  pod-name: ""
-  pod-namespace: network-hedgehog-defence
+  podName: ""
+  podNamespace: network-hedgehog-defence
 tasks:
   "1":
     hints:
-    - text: Is it possible to hit the database service from the setup pod?
-    - text: The DNS resolution across namespaces is <service>.<namespace>.
-    - text: Many databases are SQL based, could it be one of the popular ones? You
-        may need to install a query tool on the setup pod.
-    - text: Do Postgres databases have passwords by default? I wonder what the default
-        username for the SQL database is.
-    - text: Hmm, how do I list tables and view the keys in tables again?
-    - text: To query db from setupd pod ```psql -h database.network-hedgehog-defence
-        -U postgres```
-    sort-order: 1
-    starting-point:
+      - text: Is it possible to hit the database service from the setup pod?
+      - text: The DNS resolution across namespaces is <service>.<namespace>.
+      - text:
+          Many databases are SQL based, could it be one of the popular ones? You
+          may need to install a query tool on the setup pod.
+      - text:
+          Do Postgres databases have passwords by default? I wonder what the default
+          username for the SQL database is.
+      - text: Hmm, how do I list tables and view the keys in tables again?
+      - text:
+          To query db from setupd pod ```psql -h database.network-hedgehog-defence
+          -U postgres```
+    sortOrder: 1
+    startingPoint:
       mode: pod
-      pod-name: ""
-      pod-namespace: network-hedgehog-defence
+      podName: ""
+      podNamespace: network-hedgehog-defence
     summary: "Using psql we managed to get some secret data from a pod in another namespace."
   "2":
     hints:
-    - text: Put a network policy in place such that only namespace internal resources
-        can talk to the database.
-    sort-order: 2
-    starting-point:
-      kubectl-access: true
+      - text:
+          Put a network policy in place such that only namespace internal resources
+          can talk to the database.
+    sortOrder: 2
+    startingPoint:
+      kubectlAccess: true
       mode: internal-instance
     summary: "We created a network policy that only allowed the database to receive traffic from inside its namespace."

--- a/simulation-scripts/scenario/network-swarming/tasks.yaml
+++ b/simulation-scripts/scenario/network-swarming/tasks.yaml
@@ -2,7 +2,7 @@ kind: cp.simulator/scenario:1.0.0
 objective: Use misconfigured svc to compromise db.
 startingPoint:
   mode: pod
-  podName: ""
+  podName: "frontend"
   podNamespace: network-swarming
 tasks:
   "1":
@@ -22,7 +22,7 @@ tasks:
     sortOrder: 1
     startingPoint:
       mode: pod
-      podName: ""
+      podName: "frontend"
       podNamespace: network-swarming
     summary: "We used the db service in the namespace to connect to a database psql and find some secret data. We should not have been able to do this given our starting location."
   "2":

--- a/simulation-scripts/scenario/network-swarming/tasks.yaml
+++ b/simulation-scripts/scenario/network-swarming/tasks.yaml
@@ -1,33 +1,36 @@
 kind: cp.simulator/scenario:1.0.0
 objective: Use misconfigured svc to compromise db.
-starting-point:
+startingPoint:
   mode: pod
-  pod-name: ""
-  pod-namespace: network-swarming
+  podName: ""
+  podNamespace: network-swarming
 tasks:
   "1":
     hints:
-    - text: I wonder what the services for the 'database' and 'api' are called? I
-        think the names might be obvious.
-    - text: I don't think the API will be useful, can I look at the database from
-        here?
-    - text: Many databases are SQL based, could it be one of the popular ones?
-    - text: I wonder what the default username for the database is.
-    - text: One of the devs mentioned a Postgres database they used didn't have a
-        password, could this be it?
-    - text: Hmm, how do I list tables and view the keys in tables again?
-    sort-order: 1
-    starting-point:
+      - text:
+          I wonder what the services for the 'database' and 'api' are called? I
+          think the names might be obvious.
+      - text:
+          I don't think the API will be useful, can I look at the database from
+          here?
+      - text: Many databases are SQL based, could it be one of the popular ones?
+      - text: I wonder what the default username for the database is.
+      - text:
+          One of the devs mentioned a Postgres database they used didn't have a
+          password, could this be it?
+      - text: Hmm, how do I list tables and view the keys in tables again?
+    sortOrder: 1
+    startingPoint:
       mode: pod
-      pod-name: ""
-      pod-namespace: network-swarming
+      podName: ""
+      podNamespace: network-swarming
     summary: "We used the db service in the namespace to connect to a database psql and find some secret data. We should not have been able to do this given our starting location."
   "2":
     hints:
-    - text: The database shouldn't be talking to the frontend.
-    - text: I wonder if a network policy would help here.
-    sort-order: 2
-    starting-point:
-      kubectl-access: true
+      - text: The database shouldn't be talking to the frontend.
+      - text: I wonder if a network policy would help here.
+    sortOrder: 2
+    startingPoint:
+      kubectlAccess: true
       mode: internal-instance
     summary: "A Network Policy was implemented to prevent the frontend pods from interacting with the database."

--- a/simulation-scripts/scenario/node-amphibious-operations/tasks.yaml
+++ b/simulation-scripts/scenario/node-amphibious-operations/tasks.yaml
@@ -1,38 +1,44 @@
 kind: cp.simulator/scenario:1.0.0
 objective: Node compromise to get unauth kubelet API access.
-starting-point:
+startingPoint:
   mode: pod
-  pod-name: ""
-  pod-namespace: node-amphibious-operations
+  podName: ""
+  podNamespace: node-amphibious-operations
 tasks:
   "1":
     hints:
-    - text: Have you looked into the the kubelet?
-    - text: The kubelet read-write API sits on port 10250. You may need to install
-        some tools to get the information you need.
-    - text: Get the pod information from one of the nodes until you hit a good pod;
-        curl -k https://<node-IP>:10250/pods What can you do with this information?
-    - text: From the pod information you saw that there are some secrets mounted in
-        the secret-pod. Can you run any commands in the pod?
-    - text: Run the printenv command in the container you found; curl -k -XPOST "https://<node-ip>:10250/run/node-amphibious-operations/<pod
-        name>/<container name>" -d "cmd=printenv" You will be able to find the pod
-        and container name from the previous pods endpoint.
-    sort-order: 1
-    starting-point:
+      - text: Have you looked into the the kubelet?
+      - text:
+          The kubelet read-write API sits on port 10250. You may need to install
+          some tools to get the information you need.
+      - text:
+          Get the pod information from one of the nodes until you hit a good pod;
+          curl -k https://<node-IP>:10250/pods What can you do with this information?
+      - text:
+          From the pod information you saw that there are some secrets mounted in
+          the secret-pod. Can you run any commands in the pod?
+      - text:
+          Run the printenv command in the container you found; curl -k -XPOST "https://<node-ip>:10250/run/node-amphibious-operations/<pod
+          name>/<container name>" -d "cmd=printenv" You will be able to find the pod
+          and container name from the previous pods endpoint.
+    sortOrder: 1
+    startingPoint:
       mode: pod
-      pod-name: ""
-      pod-namespace: node-amphibious-operations
+      podName: ""
+      podNamespace: node-amphibious-operations
     summary: "We were able to query the kubelet api directly and get some sensitive data about the pods. We then took this further and used our access to run arbitrary commands inside the pod."
   "2":
     hints:
-    - text: You need to fix /var/lib/kubelet/config.yaml.
-    - text: "'authentication.anonymous.enabled' value should be 'false' and 'authorization.mode'
-        should be 'Webhook'."
-    - text: "'systemctl daemon-reload; systemctl restart kubelet.service' applies
-        the config changes."
-    sort-order: 2
-    starting-point:
-      as-root: true
+      - text: You need to fix /var/lib/kubelet/config.yaml.
+      - text:
+          "'authentication.anonymous.enabled' value should be 'false' and 'authorization.mode'
+          should be 'Webhook'."
+      - text:
+          "'systemctl daemon-reload; systemctl restart kubelet.service' applies
+          the config changes."
+    sortOrder: 2
+    startingPoint:
+      asRoot: true
       mode: node
-      node-id: node-0
+      nodeId: node-0
     summary: "We edited the kubelet yaml to disable anonymous authentication and enforce the webhook authentication mode. We then restarted the kubelet."

--- a/simulation-scripts/scenario/node-amphibious-operations/tasks.yaml
+++ b/simulation-scripts/scenario/node-amphibious-operations/tasks.yaml
@@ -2,7 +2,7 @@ kind: cp.simulator/scenario:1.0.0
 objective: Node compromise to get unauth kubelet API access.
 startingPoint:
   mode: pod
-  podName: ""
+  podName: "start-pod"
   podNamespace: node-amphibious-operations
 tasks:
   "1":
@@ -24,7 +24,7 @@ tasks:
     sortOrder: 1
     startingPoint:
       mode: pod
-      podName: ""
+      podName: "start-pod"
       podNamespace: node-amphibious-operations
     summary: "We were able to query the kubelet api directly and get some sensitive data about the pods. We then took this further and used our access to run arbitrary commands inside the pod."
   "2":

--- a/simulation-scripts/scenario/node-raiding/challenge.txt
+++ b/simulation-scripts/scenario/node-raiding/challenge.txt
@@ -2,7 +2,7 @@ Scenario: A secret has been leaked from your application through the pod configu
 Your audit logs indicate that it hasn't been requested through the Kubernetes API.
 You have recently read a blog post about how to exfiltrate secrets with just network access to your nodes, $NODE_IP_ADDRESSES
 
-Starting Point: start-pod pod in node-raiding namespace
+Starting Point: start-pod pod in the node-raiding namespace
 
 Difficulty:  Medium
 

--- a/simulation-scripts/scenario/node-raiding/tasks.yaml
+++ b/simulation-scripts/scenario/node-raiding/tasks.yaml
@@ -1,31 +1,33 @@
 kind: cp.simulator/scenario:1.0.0
 objective: Node compromise to get readonly kubelet API access.
-starting-point:
+startingPoint:
   mode: pod
-  pod-name: ""
-  pod-namespace: node-raiding
+  podName: ""
+  podNamespace: node-raiding
 tasks:
   "1":
     hints:
-    - text: Have you looked into the the kubelet?
-    - text: The kubelet readonly API sits on port 10255.
-    - text: Get anything directly from the kubelet API, circumventing the Kubernetes
-        server API, e.g. curl http://<node-IP>:10255/pods
-    sort-order: 1
-    starting-point:
+      - text: Have you looked into the the kubelet?
+      - text: The kubelet readonly API sits on port 10255.
+      - text:
+          Get anything directly from the kubelet API, circumventing the Kubernetes
+          server API, e.g. curl http://<node-IP>:10255/pods
+    sortOrder: 1
+    startingPoint:
       mode: pod
-      pod-name: ""
-      pod-namespace: node-raiding
+      podName: ""
+      podNamespace: node-raiding
     summary: "We queried the outdated kublet readonly port to get pod information."
   "2":
     hints:
-    - text: You need to fix /var/lib/kubelet/config.yaml.
-    - text: readOnly port should be 0.
-    - text: "'systemctl daemon-reload; systemctl restart kubelet.service' applies
-        the config changes."
-    sort-order: 2
-    starting-point:
-      as-root: true
+      - text: You need to fix /var/lib/kubelet/config.yaml.
+      - text: readOnly port should be 0.
+      - text:
+          "'systemctl daemon-reload; systemctl restart kubelet.service' applies
+          the config changes."
+    sortOrder: 2
+    startingPoint:
+      asRoot: true
       mode: node
-      node-id: node-0
+      nodeId: node-0
     summary: "We disabled the readonly port in the kubelet config and restarted the service."

--- a/simulation-scripts/scenario/node-raiding/tasks.yaml
+++ b/simulation-scripts/scenario/node-raiding/tasks.yaml
@@ -2,7 +2,7 @@ kind: cp.simulator/scenario:1.0.0
 objective: Node compromise to get readonly kubelet API access.
 startingPoint:
   mode: pod
-  podName: ""
+  podName: "start-pod"
   podNamespace: node-raiding
 tasks:
   "1":
@@ -15,7 +15,7 @@ tasks:
     sortOrder: 1
     startingPoint:
       mode: pod
-      podName: ""
+      podName: "start-pod"
       podNamespace: node-raiding
     summary: "We queried the outdated kublet readonly port to get pod information."
   "2":

--- a/simulation-scripts/scenario/node-shock-tactics/tasks.yaml
+++ b/simulation-scripts/scenario/node-shock-tactics/tasks.yaml
@@ -1,29 +1,29 @@
 kind: cp.simulator/scenario:1.0.0
 objective: Node escalation to workload compromise.
-starting-point:
-  kubectl-access: false
+startingPoint:
+  kubectlAccess: false
   mode: internal-instance
 tasks:
   "1":
     hints:
-    - text: How would you escalate yourself on this node?
-    - text: Is there a file in /etc/ you can manipulate?
-    - text: Where do pods store their secrets?
-    - text: Incorrect permissions on /etc/shadow.
-    - text: /etc/shadow manipulation.
-    - text: Set root password for host.
-    - text: Login as root.
-    sort-order: 1
-    starting-point:
-      kubectl-access: false
+      - text: How would you escalate yourself on this node?
+      - text: Is there a file in /etc/ you can manipulate?
+      - text: Where do pods store their secrets?
+      - text: Incorrect permissions on /etc/shadow.
+      - text: /etc/shadow manipulation.
+      - text: Set root password for host.
+      - text: Login as root.
+    sortOrder: 1
+    startingPoint:
+      kubectlAccess: false
       mode: internal-instance
     summary: "We manipulated some malformed /etc/shadow permissions to escalate ourselves to root on the node."
   "2":
     hints:
-    - text: "'df -h' as host root to see tmpfs mounts."
-    - text: Read creds from tmpfs volume.
-    sort-order: 2
-    starting-point:
-      kubectl-access: false
+      - text: "'df -h' as host root to see tmpfs mounts."
+      - text: Read creds from tmpfs volume.
+    sortOrder: 2
+    startingPoint:
+      kubectlAccess: false
       mode: internal-instance
     summary: "We used our root privileges to read secret data from tmpfs mount inside the container."

--- a/simulation-scripts/scenario/noop/tasks.yaml
+++ b/simulation-scripts/scenario/noop/tasks.yaml
@@ -1,4 +1,4 @@
 kind: cp.simulator/scenario:1.0.0
 objective: Do nothing
-starting-point: ""
+startingPoint: ""
 tasks: {}

--- a/simulation-scripts/scenario/policy-echelon-formation/challenge.txt
+++ b/simulation-scripts/scenario/policy-echelon-formation/challenge.txt
@@ -1,4 +1,4 @@
-Scenario: A new process monitoring tool has been deployed to your cluster. A fellow security engineer has audited the deployment and believes that the current configuration can allow a compromised pod this deployment to further compromise any other container on the same host.
+Scenario: A new process monitoring tool has been deployed to your cluster. A fellow security engineer has audited the deployment and believes that the current configuration can allow a compromised pod in this deployment to further compromise any other container on the same host.
 
 Starting Point: process-monitor pod in the policy-echelon-formation namespace.
 

--- a/simulation-scripts/scenario/policy-echelon-formation/challenge.txt
+++ b/simulation-scripts/scenario/policy-echelon-formation/challenge.txt
@@ -1,6 +1,6 @@
 Scenario: A new process monitoring tool has been deployed to your cluster. A fellow security engineer has audited the deployment and believes that the current configuration can allow a compromised pod this deployment to further compromise any other container on the same host.
 
-Starting Point: process-monitoring pod in the policy-echelon-formation namespace.
+Starting Point: process-monitor pod in the policy-echelon-formation namespace.
 
 Difficulty: Hard
 

--- a/simulation-scripts/scenario/policy-echelon-formation/tasks.yaml
+++ b/simulation-scripts/scenario/policy-echelon-formation/tasks.yaml
@@ -2,7 +2,7 @@ kind: cp.simulator/scenario:1.0.0
 objective: Use privileged container to get host secrets.
 startingPoint:
   mode: pod
-  podName: ""
+  podName: "process-monitor"
   podNamespace: policy-echelon-formation
 tasks:
   "1":
@@ -20,15 +20,17 @@ tasks:
     sortOrder: 1
     startingPoint:
       mode: pod
-      podName: ""
+      podName: "process-monitor"
       podNamespace: policy-echelon-formation
     summary: "Using the elevated permissions on the pod, we managed to manipulate the node /proc to retrieve secrets from another pod."
   "2":
     hints:
       - text: Looks like I need to  stop adding ALL capabilities to the pod.
     sortOrder: 2
-    startingPoint: ""
-    summary: ""
+    startingPoint:
+      kubectlAccess: true
+      mode: internal-instance
+    summary: "We removed the 'ALL' capabilities from the pod"
   "3":
     hints:
       - text: I think a PodSecurityPolicy might be useful here.

--- a/simulation-scripts/scenario/policy-echelon-formation/tasks.yaml
+++ b/simulation-scripts/scenario/policy-echelon-formation/tasks.yaml
@@ -1,41 +1,44 @@
 kind: cp.simulator/scenario:1.0.0
 objective: Use privileged container to get host secrets.
-starting-point:
+startingPoint:
   mode: pod
-  pod-name: ""
-  pod-namespace: policy-echelon-formation
+  podName: ""
+  podNamespace: policy-echelon-formation
 tasks:
   "1":
     hints:
-    - text: I wonder if I can see the host processes in this container since it is
-        a process monitor?
-    - text: Hmm, if I can see the proccesses I wonder what /proc looks like?
-    - text: I'm looking for a postgres process so I should find its pid and check
-        /proc for that pid.
-    - text: Let's see if /proc/<pid>/environ has one of the values we need.
-    - text: What's in /proc/<pid>/root?
-    - text: The final secrets I need are in /proc/<pid>/root/secrets.
-    sort-order: 1
-    starting-point:
+      - text:
+          I wonder if I can see the host processes in this container since it is
+          a process monitor?
+      - text: Hmm, if I can see the proccesses I wonder what /proc looks like?
+      - text:
+          I'm looking for a postgres process so I should find its pid and check
+          /proc for that pid.
+      - text: Let's see if /proc/<pid>/environ has one of the values we need.
+      - text: What's in /proc/<pid>/root?
+      - text: The final secrets I need are in /proc/<pid>/root/secrets.
+    sortOrder: 1
+    startingPoint:
       mode: pod
-      pod-name: ""
-      pod-namespace: policy-echelon-formation
+      podName: ""
+      podNamespace: policy-echelon-formation
     summary: "Using the elevated permissions on the pod, we managed to manipulate the node /proc to retrieve secrets from another pod."
   "2":
     hints:
-    - text: Looks like I need to  stop adding ALL capabilities to the pod.
-    sort-order: 2
-    starting-point: ""
+      - text: Looks like I need to  stop adding ALL capabilities to the pod.
+    sortOrder: 2
+    startingPoint: ""
     summary: ""
   "3":
     hints:
-    - text: I think a PodSecurityPolicy might be useful here.
-    - text: Remember to set a default policy before enabling the PSP in both the kube-system
-        and policy-vertical-envelopment namespaces
-    - text: I'll need to enable the PSP controller in the api-server.
-    - text: My PSP for Jenkins should prevent adding ALL capabilities to pods.
-    sort-order: 3
-    starting-point:
-      kubectl-access: true
+      - text: I think a PodSecurityPolicy might be useful here.
+      - text:
+          Remember to set a default policy before enabling the PSP in both the kube-system
+          and policy-vertical-envelopment namespaces
+      - text: I'll need to enable the PSP controller in the api-server.
+      - text: My PSP for Jenkins should prevent adding ALL capabilities to pods.
+    sortOrder: 3
+    startingPoint:
+      kubectlAccess: true
       mode: internal-instance
     summary: "We used a pod security policy to limit what linux capabilities pods in our cluster can have."

--- a/simulation-scripts/scenario/policy-fire-support/tasks.yaml
+++ b/simulation-scripts/scenario/policy-fire-support/tasks.yaml
@@ -2,7 +2,7 @@ kind: cp.simulator/scenario:1.0.0
 objective: Use Sudo to get un readable ssh keys from a host mount.
 startingPoint:
   mode: pod
-  podName: ""
+  podName: "jenkins"
   podNamespace: policy-fire-support
 tasks:
   "1":
@@ -13,7 +13,7 @@ tasks:
     sortOrder: 1
     startingPoint:
       mode: pod
-      podName: ""
+      podName: "jenkins"
       podNamespace: policy-fire-support
     summary: "Using sudo in the container, we managed to bypass some linux file permissions for a file on the host."
   "2":

--- a/simulation-scripts/scenario/policy-fire-support/tasks.yaml
+++ b/simulation-scripts/scenario/policy-fire-support/tasks.yaml
@@ -1,28 +1,28 @@
 kind: cp.simulator/scenario:1.0.0
 objective: Use Sudo to get un readable ssh keys from a host mount.
-starting-point:
+startingPoint:
   mode: pod
-  pod-name: ""
-  pod-namespace: policy-fire-support
+  podName: ""
+  podNamespace: policy-fire-support
 tasks:
   "1":
     hints:
-    - text: I should look around and see if I can find those keys.
-    - text: Hmm I can't seem to open /root-ssh.
-    - text: Is sudo installed in this container?
-    sort-order: 1
-    starting-point:
+      - text: I should look around and see if I can find those keys.
+      - text: Hmm I can't seem to open /root-ssh.
+      - text: Is sudo installed in this container?
+    sortOrder: 1
+    startingPoint:
       mode: pod
-      pod-name: ""
-      pod-namespace: policy-fire-support
+      podName: ""
+      podNamespace: policy-fire-support
     summary: "Using sudo in the container, we managed to bypass some linux file permissions for a file on the host."
   "2":
     hints:
-    - text: I wonder if there is a PodSecurityPolicy on this deployment.
-    - text: Looks like the Jenkins PSP is the one I want.
-    - text: I think all I need to do is prevent privilege escalation.
-    sort-order: 2
-    starting-point:
-      kubectl-access: true
+      - text: I wonder if there is a PodSecurityPolicy on this deployment.
+      - text: Looks like the Jenkins PSP is the one I want.
+      - text: I think all I need to do is prevent privilege escalation.
+    sortOrder: 2
+    startingPoint:
+      kubectlAccess: true
       mode: internal-instance
     summary: ""

--- a/simulation-scripts/scenario/policy-force-dispersal/tasks.yaml
+++ b/simulation-scripts/scenario/policy-force-dispersal/tasks.yaml
@@ -1,18 +1,18 @@
 kind: cp.simulator/scenario:1.0.0
 objective: Enable PodSecurityPolicy in the API server.
-starting-point:
-  as-root: true
+startingPoint:
+  asRoot: true
   mode: node
-  node-id: master-0
+  nodeId: master-0
 tasks:
   "1":
     hints:
-    - text: Hmm, the RBAC looks good. What other factors could influence the permissions?
-    - text: Where does kubeadm keep the master config?
-    - text: Looks like the PodSecurityPolicy is missing from the admission controllers.
-    sort-order: 1
-    starting-point:
-      as-root: true
+      - text: Hmm, the RBAC looks good. What other factors could influence the permissions?
+      - text: Where does kubeadm keep the master config?
+      - text: Looks like the PodSecurityPolicy is missing from the admission controllers.
+    sortOrder: 1
+    startingPoint:
+      asRoot: true
       mode: node
-      node-id: master-0
+      nodeId: master-0
     summary: "We re-enabled the pod security policy admission controller in the master api config."

--- a/simulation-scripts/scenario/policy-vertical-envelopment/challenge.txt
+++ b/simulation-scripts/scenario/policy-vertical-envelopment/challenge.txt
@@ -1,6 +1,6 @@
 Scenario: You have a Jenkins container provisioned by another team running in the "policy-vertical-envelopment" namespace. This container has a suspected vulnerability and is the suspected vector for a previous node compromise. You have been assured that this container does not do any Docker builds so does not have the Docker socket mounted.
 
-Starting Point: Jenkins pod in the policy-vertical-envelopment namespace.
+Starting Point: The jenkins pod in the policy-vertical-envelopment namespace.
 
 Difficulty: Medium
 

--- a/simulation-scripts/scenario/policy-vertical-envelopment/tasks.yaml
+++ b/simulation-scripts/scenario/policy-vertical-envelopment/tasks.yaml
@@ -2,7 +2,7 @@ kind: cp.simulator/scenario:1.0.0
 objective: Use privileged container to get host secrets.
 startingPoint:
   mode: pod
-  podName: ""
+  podName: "jenkins"
   podNamespace: policy-vertical-envelopment
 tasks:
   "1":
@@ -16,7 +16,7 @@ tasks:
     sortOrder: 1
     startingPoint:
       mode: pod
-      podName: ""
+      podName: "jenkins"
       podNamespace: policy-vertical-envelopment
     summary: "Using the fact that we were in a privileged container, we mounted the host disk to find a secret."
   "2":

--- a/simulation-scripts/scenario/policy-vertical-envelopment/tasks.yaml
+++ b/simulation-scripts/scenario/policy-vertical-envelopment/tasks.yaml
@@ -1,41 +1,42 @@
 kind: cp.simulator/scenario:1.0.0
 objective: Use privileged container to get host secrets.
-starting-point:
+startingPoint:
   mode: pod
-  pod-name: ""
-  pod-namespace: policy-vertical-envelopment
+  podName: ""
+  podNamespace: policy-vertical-envelopment
 tasks:
   "1":
     hints:
-    - text: What mounts do I have in this container.
-    - text: Hmm that's a lot of devices mounted to /dev.
-    - text: Is this a privileged container?
-    - text: I think I can mount the host disk.
-    - text: Looks like the xvda1 is the host disk.
-    - text: The secret I need is in the node-secret directory.
-    sort-order: 1
-    starting-point:
+      - text: What mounts do I have in this container.
+      - text: Hmm that's a lot of devices mounted to /dev.
+      - text: Is this a privileged container?
+      - text: I think I can mount the host disk.
+      - text: Looks like the xvda1 is the host disk.
+      - text: The secret I need is in the node-secret directory.
+    sortOrder: 1
+    startingPoint:
       mode: pod
-      pod-name: ""
-      pod-namespace: policy-vertical-envelopment
+      podName: ""
+      podNamespace: policy-vertical-envelopment
     summary: "Using the fact that we were in a privileged container, we mounted the host disk to find a secret."
   "2":
     hints:
-    - text: Looks like I need to set privileged to false.
-    sort-order: 2
-    starting-point:
-      kubectl-access: true
+      - text: Looks like I need to set privileged to false.
+    sortOrder: 2
+    startingPoint:
+      kubectlAccess: true
       mode: internal-instance
     summary: "We mitigated this vulnerability by editing the pod manifest to remove the privileged flag."
   "3":
     hints:
-    - text: I think a PodSecurityPolicy might be useful here.
-    - text: Remember to set a default policy before enabling the PSP in both the kube-system
-        and policy-vertical-envelopment namespaces
-    - text: I'll need to enable the PSP controller in the api-server.
-    - text: My PSP for Jenkins should prevent 'privileged= true'.
-    sort-order: 3
-    starting-point:
-      kubectl-access: true
+      - text: I think a PodSecurityPolicy might be useful here.
+      - text:
+          Remember to set a default policy before enabling the PSP in both the kube-system
+          and policy-vertical-envelopment namespaces
+      - text: I'll need to enable the PSP controller in the api-server.
+      - text: My PSP for Jenkins should prevent 'privileged= true'.
+    sortOrder: 3
+    startingPoint:
+      kubectlAccess: true
       mode: internal-instance
     summary: "We implemented a pod security policy to prevent anyone setting the privileged flag without approval."

--- a/simulation-scripts/scenario/rbac-contact-drill/tasks.yaml
+++ b/simulation-scripts/scenario/rbac-contact-drill/tasks.yaml
@@ -1,29 +1,32 @@
 kind: cp.simulator/scenario:1.0.0
-objective: Figure out additional permissions given to the default service account
+objective:
+  Figure out additional permissions given to the default service account
   and reassign to designated role.
-starting-point:
+startingPoint:
   mode: pod
-  pod-name: ""
-  pod-namespace: rbac-contact-drill
+  podName: ""
+  podNamespace: rbac-contact-drill
 tasks:
   "1":
     hints:
-    - text: Can you hit the API from inside the pod? You may need to install curl
-        and kubectl.
-    sort-order: 1
-    starting-point:
+      - text:
+          Can you hit the API from inside the pod? You may need to install curl
+          and kubectl.
+    sortOrder: 1
+    startingPoint:
       mode: pod
-      pod-name: ""
-      pod-namespace: rbac-contact-drill
+      podName: ""
+      podNamespace: rbac-contact-drill
     summary: "We managed to hit the kubernetes api from inside the pod and used kubectl to query it."
   "2":
     hints:
-    - text: What identity is assigned the pod? Check out the service account directory.
-    - text: Have a look at the roles and rolebindings.
-    - text: The default service account has permissions to view secrets. Make a new
-        role with these permissions and assign it to the secrets-caller deployment
-    sort-order: 2
-    starting-point:
-      kubectl-access: true
+      - text: What identity is assigned the pod? Check out the service account directory.
+      - text: Have a look at the roles and rolebindings.
+      - text:
+          The default service account has permissions to view secrets. Make a new
+          role with these permissions and assign it to the secrets-caller deployment
+    sortOrder: 2
+    startingPoint:
+      kubectlAccess: true
       mode: internal-instance
     summary: "We removed the view secrets permission from the default namespace service account. We then created a new service account with those permissions for the exclusive use of the secrets-caller pod."

--- a/simulation-scripts/scenario/rbac-contact-drill/tasks.yaml
+++ b/simulation-scripts/scenario/rbac-contact-drill/tasks.yaml
@@ -4,7 +4,7 @@ objective:
   and reassign to designated role.
 startingPoint:
   mode: pod
-  podName: ""
+  podName: "ubuntu"
   podNamespace: rbac-contact-drill
 tasks:
   "1":
@@ -15,7 +15,7 @@ tasks:
     sortOrder: 1
     startingPoint:
       mode: pod
-      podName: ""
+      podName: "ubuntu"
       podNamespace: rbac-contact-drill
     summary: "We managed to hit the kubernetes api from inside the pod and used kubectl to query it."
   "2":

--- a/simulation-scripts/scenario/rbac-flanking-maneuver/tasks.yaml
+++ b/simulation-scripts/scenario/rbac-flanking-maneuver/tasks.yaml
@@ -1,38 +1,41 @@
 kind: cp.simulator/scenario:1.0.0
 objective: SSH into vulnerable workload, wget secrets using permissive SA.
-starting-point:
-  kubectl-access: false
+startingPoint:
+  kubectlAccess: false
   mode: internal-instance
 tasks:
   "1":
     hints:
-    - text: Find open SSH port in workload. You can use nmap. Remember it runs on
-        a NodePort.
-    - text: The open NodePort was 30022. Brute force host SSH default password.
-    - text: Username is admin and password is password.
-    - text: Look around for credentials and tools. Can you hit the API?
-    - text: Use wget to hit the API at default port 6443. The service account token
-        looks like it can schedule workloads and get secrets.
-    sort-order: 1
-    starting-point:
-      kubectl-access: false
+      - text:
+          Find open SSH port in workload. You can use nmap. Remember it runs on
+          a NodePort.
+      - text: The open NodePort was 30022. Brute force host SSH default password.
+      - text: Username is admin and password is password.
+      - text: Look around for credentials and tools. Can you hit the API?
+      - text:
+          Use wget to hit the API at default port 6443. The service account token
+          looks like it can schedule workloads and get secrets.
+    sortOrder: 1
+    startingPoint:
+      kubectlAccess: false
       mode: internal-instance
     summary: "We brute forced access to an SSH pod in the cluster with an active node port and weak password. We then used the pods elevated permissions to get secrets."
   "2":
     hints:
-    - text: What identity is assigned the pod?
-    - text: Have a look at the roles and rolebindings.
-    - text: Since the pod doesn't need to talk to the API, you can just delete the
-        rolebinding.
-    sort-order: 2
-    starting-point:
-      kubectl-access: true
+      - text: What identity is assigned the pod?
+      - text: Have a look at the roles and rolebindings.
+      - text:
+          Since the pod doesn't need to talk to the API, you can just delete the
+          rolebinding.
+    sortOrder: 2
+    startingPoint:
+      kubectlAccess: true
       mode: internal-instance
     summary: "We removed the rolebinding giving elevated permissions to the pod."
   "3":
     hints:
-    - text: Don't use passwords for SSH connections, and definitely not easy ones.
-    sort-order: 3
-    starting-point:
+      - text: Don't use passwords for SSH connections, and definitely not easy ones.
+    sortOrder: 3
+    startingPoint:
       mode: null
     summary: "We should not use passwords for SSH. Where we do need to use passwords we should not pick simple or obvious ones. "

--- a/simulation-scripts/scenario/rbac-sangar/tasks.yaml
+++ b/simulation-scripts/scenario/rbac-sangar/tasks.yaml
@@ -1,52 +1,57 @@
 kind: cp.simulator/scenario:1.0.0
-objective: Figure out additional permissions given to system:authenticated group and
+objective:
+  Figure out additional permissions given to system:authenticated group and
   remove them.
-starting-point:
+startingPoint:
   mode: pod
-  pod-name: ""
-  pod-namespace: rbac-sangar
+  podName: ""
+  podNamespace: rbac-sangar
 tasks:
   "1":
     hints:
-    - text: Can I run or install kubectl in here?
-    - text: Hmm, I can't see secrets directly. I wonder what the deployment of the
-        application pods looks like?
-    - text: The secret is in an environment variable in the application pods.
-    sort-order: 1
-    starting-point:
+      - text: Can I run or install kubectl in here?
+      - text:
+          Hmm, I can't see secrets directly. I wonder what the deployment of the
+          application pods looks like?
+      - text: The secret is in an environment variable in the application pods.
+    sortOrder: 1
+    startingPoint:
       mode: pod
-      pod-name: ""
-      pod-namespace: rbac-sangar
+      podName: ""
+      podNamespace: rbac-sangar
     summary: "We installed kubectl into the pod and used the pods elevated permissions to get a sensitive environment variable from another pod."
   "2":
     hints:
-    - text: Is there a RoleBinding in this namespace or a ClusterRoleBinding bound
-        to the namespace default ServiceAccount?
-    - text: Looks like there is not a direct binding to the ServiceAccount.
-    - text: Using the pod's token we are in the system:authenticated group. Is something
-        bound to that?
-    - text: Looks like the authenticated-view ClusterRoleBinding is giving the group
-        more permissions! It should probably be deleted for now.
-    sort-order: 2
-    starting-point:
-      kubectl-access: true
+      - text:
+          Is there a RoleBinding in this namespace or a ClusterRoleBinding bound
+          to the namespace default ServiceAccount?
+      - text: Looks like there is not a direct binding to the ServiceAccount.
+      - text:
+          Using the pod's token we are in the system:authenticated group. Is something
+          bound to that?
+      - text:
+          Looks like the authenticated-view ClusterRoleBinding is giving the group
+          more permissions! It should probably be deleted for now.
+    sortOrder: 2
+    startingPoint:
+      kubectlAccess: true
       mode: internal-instance
     summary: "We found that there wasn't a rolebinding applied to the service account. Instead we saw that the default service account inherits the 'system:authenticated' group and there were elevated permissions applied to that group."
   "3":
     hints:
-    - text: The pod should not mount the default service token.
-    - text: The application pods already do this. Maybe I could look there for inspiration.
-    - text: I need to set automountServiceAccountToken to be false
-    sort-order: 3
-    starting-point:
-      kubectl-access: true
+      - text: The pod should not mount the default service token.
+      - text: The application pods already do this. Maybe I could look there for inspiration.
+      - text: I need to set automountServiceAccountToken to be false
+    sortOrder: 3
+    startingPoint:
+      kubectlAccess: true
       mode: internal-instance
     summary: "We unmounted the default service account token from the pod."
   "4":
     hints:
-    - text: I need to replace the environment variable with a secret.
-    sort-order: 4
-    starting-point:
-      kubectl-access: true
+      - text: I need to replace the environment variable with a secret.
+    sortOrder: 4
+    startingPoint:
+      kubectlAccess: true
       mode: internal-instance
     summary: "We replaced the compromised environment variable with a kubernetes secret."

--- a/simulation-scripts/scenario/rbac-sangar/tasks.yaml
+++ b/simulation-scripts/scenario/rbac-sangar/tasks.yaml
@@ -4,7 +4,7 @@ objective:
   remove them.
 startingPoint:
   mode: pod
-  podName: ""
+  podName: "frontend"
   podNamespace: rbac-sangar
 tasks:
   "1":
@@ -17,7 +17,7 @@ tasks:
     sortOrder: 1
     startingPoint:
       mode: pod
-      podName: ""
+      podName: "frontend"
       podNamespace: rbac-sangar
     summary: "We installed kubectl into the pod and used the pods elevated permissions to get a sensitive environment variable from another pod."
   "2":

--- a/simulation-scripts/scenario/rbac-shoot-and-scoot/tasks.yaml
+++ b/simulation-scripts/scenario/rbac-shoot-and-scoot/tasks.yaml
@@ -1,32 +1,33 @@
 kind: cp.simulator/scenario:1.0.0
-objective: Figure out additional permissions given to system:anonymous role and remove
+objective:
+  Figure out additional permissions given to system:anonymous role and remove
   them.
-starting-point:
+startingPoint:
   mode: pod
-  pod-name: ""
-  pod-namespace: rbac-shoot-and-scoot
+  podName: ""
+  podNamespace: rbac-shoot-and-scoot
 tasks:
   "1":
     hints:
-    - text: Can you hit the API from inside the pod? What is the DNS resolvable name?
-    - text: What do we get from `printenv`?
-    - text: That looks like the IP and port for the API server!
-    - text: I reckon I can curl that endpoint if I use HTTPS and the -k option
-    - text: How do I navigate the HTTP API to find a secret?
-    - text: "I think this might work: 'curl -k https://<your-host-and-port>/api/v1/namespaces/rbac-shoot-and-scoot/serets/credentials'"
-    sort-order: 1
-    starting-point:
+      - text: Can you hit the API from inside the pod? What is the DNS resolvable name?
+      - text: What do we get from `printenv`?
+      - text: That looks like the IP and port for the API server!
+      - text: I reckon I can curl that endpoint if I use HTTPS and the -k option
+      - text: How do I navigate the HTTP API to find a secret?
+      - text: "I think this might work: 'curl -k https://<your-host-and-port>/api/v1/namespaces/rbac-shoot-and-scoot/serets/credentials'"
+    sortOrder: 1
+    startingPoint:
       mode: pod
-      pod-name: ""
-      pod-namespace: rbac-shoot-and-scoot
+      podName: ""
+      podNamespace: rbac-shoot-and-scoot
     summary: "We used curl and the environment variables in the pod to get a secret from the namespace without passing the api server a token."
   "2":
     hints:
-    - text: What user is assigned when hitting the API with no identity?
-    - text: Have a look at the rolebindings and clusterrolebindings
-    - text: system:anonymous has a clusterrolebinding to admin. Remove this binding.
-    sort-order: 2
-    starting-point:
-      kubectl-access: true
+      - text: What user is assigned when hitting the API with no identity?
+      - text: Have a look at the rolebindings and clusterrolebindings
+      - text: system:anonymous has a clusterrolebinding to admin. Remove this binding.
+    sortOrder: 2
+    startingPoint:
+      kubectlAccess: true
       mode: internal-instance
     summary: "We removed a cluster role binding giving anonymous requests cluster admin."

--- a/simulation-scripts/scenario/rbac-shoot-and-scoot/tasks.yaml
+++ b/simulation-scripts/scenario/rbac-shoot-and-scoot/tasks.yaml
@@ -4,7 +4,7 @@ objective:
   them.
 startingPoint:
   mode: pod
-  podName: ""
+  podName: "ubuntu"
   podNamespace: rbac-shoot-and-scoot
 tasks:
   "1":
@@ -18,7 +18,7 @@ tasks:
     sortOrder: 1
     startingPoint:
       mode: pod
-      podName: ""
+      podName: "ubuntu"
       podNamespace: rbac-shoot-and-scoot
     summary: "We used curl and the environment variables in the pod to get a secret from the namespace without passing the api server a token."
   "2":

--- a/simulation-scripts/scenario/secret-high-ground/tasks.yaml
+++ b/simulation-scripts/scenario/secret-high-ground/tasks.yaml
@@ -1,26 +1,27 @@
 kind: cp.simulator/scenario:1.0.0
 objective: Fix a pull policy and then add a secret to the pod.
-starting-point:
-  kubectl-access: true
+startingPoint:
+  kubectlAccess: true
   mode: internal-instance
 tasks:
   "1":
     hints:
-    - text: I should probably check the deployment.
-    - text: Is the a flag I can update that will force the container to pull from
-        the offical repository?
-    - text: I should set the PullPolicy flag to Always.
-    sort-order: 1
-    starting-point:
-      kubectl-access: true
+      - text: I should probably check the deployment.
+      - text:
+          Is the a flag I can update that will force the container to pull from
+          the offical repository?
+      - text: I should set the PullPolicy flag to Always.
+    sortOrder: 1
+    startingPoint:
+      kubectlAccess: true
       mode: internal-instance
     summary: We set pull policy of the pod to always.""
   "2":
     hints:
-    - text: A kubernetes secret is the best choice here.
-    - text: I can mount the secret data as a file into the pod.
-    sort-order: 2
-    starting-point:
-      kubectl-access: true
+      - text: A kubernetes secret is the best choice here.
+      - text: I can mount the secret data as a file into the pod.
+    sortOrder: 2
+    startingPoint:
+      kubectlAccess: true
       mode: internal-instance
     summary: "We replaced the file baked into the container image with a kubernetes secret mounted in to the container at runtime."

--- a/simulation-scripts/scenario/secret-tank-desant/tasks.yaml
+++ b/simulation-scripts/scenario/secret-tank-desant/tasks.yaml
@@ -1,18 +1,18 @@
 kind: cp.simulator/scenario:1.0.0
 objective: Compromise secret from running workload.
-starting-point:
+startingPoint:
   mode: pod
-  pod-name: ""
-  pod-namespace: secret-tank-desant
+  podName: ""
+  podNamespace: secret-tank-desant
 tasks:
   "1":
     hints:
-    - text: kubectl exec into workload.
-    - text: Workload - enumerate container filesystem.
-    - text: Read AWS creds from file.
-    sort-order: 1
-    starting-point:
+      - text: kubectl exec into workload.
+      - text: Workload - enumerate container filesystem.
+      - text: Read AWS creds from file.
+    sortOrder: 1
+    startingPoint:
       mode: pod
-      pod-name: ""
-      pod-namespace: secret-tank-desant
+      podName: ""
+      podNamespace: secret-tank-desant
     summary: "We read some secret data from the filesystem."

--- a/simulation-scripts/scenario/secret-tank-desant/tasks.yaml
+++ b/simulation-scripts/scenario/secret-tank-desant/tasks.yaml
@@ -2,7 +2,7 @@ kind: cp.simulator/scenario:1.0.0
 objective: Compromise secret from running workload.
 startingPoint:
   mode: pod
-  podName: ""
+  podName: "nginx"
   podNamespace: secret-tank-desant
 tasks:
   "1":
@@ -13,6 +13,6 @@ tasks:
     sortOrder: 1
     startingPoint:
       mode: pod
-      podName: ""
+      podName: "nginx"
       podNamespace: secret-tank-desant
     summary: "We read some secret data from the filesystem."


### PR DESCRIPTION
Add starting point functionality for pods. The format of the `tasks.yaml` was changed slightly to remove `-` from key names as these needed to be escaped when manipulating the yaml as json.

Perturb ended up going through `shfmt` so there are a lot of non functional formatting changes in there. The functional changes are in the new `template_tasks` function.

Resolves #180 
