### PR TITLE
Fix tests  - OSX

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update                                                              
     unzip
 
 # Download and save golang latest for use in other layers and install
-ARG GO_INSTALL_VERSION=1.13.5
+ARG GO_INSTALL_VERSION=1.13.7
 # hadolint ignore=DL3003,DL3010
 RUN mkdir /downloads                                                  \
     && cd /downloads                                                  \

--- a/pkg/simulator/terraform_vars.go
+++ b/pkg/simulator/terraform_vars.go
@@ -28,7 +28,7 @@ func (tfv *TfVars) String() string {
 
 }
 
-// EnsureLatestTfVarsFile writes an tfvars file if one hasnt already been made
+// EnsureLatestTfVarsFile always writes an tfvars file
 func EnsureLatestTfVarsFile(tfVarsDir, publicKey, accessCIDR, bucket, attackTag string) error {
 	filename := tfVarsDir + "/settings/bastion.tfvars"
 	tfv := NewTfVars(publicKey, accessCIDR, bucket, attackTag)

--- a/pkg/simulator/terraform_vars_test.go
+++ b/pkg/simulator/terraform_vars_test.go
@@ -29,7 +29,7 @@ func Test_Ensure_TfVarsFile_with_settings(t *testing.T) {
 	defer os.Remove(workDir)
 	require.NoError(t, os.Mkdir(filepath.Join(workDir, "settings"), 0700))
 
-	bastionVarsFile := filepath.Join(workDir, "settings", "bastion.tfVars")
+	bastionVarsFile := filepath.Join(workDir, "settings", "bastion.tfvars")
 	err = ioutil.WriteFile(bastionVarsFile, []byte("any=content"), 0644)
 	require.NoError(t, err)
 

--- a/pkg/simulator/terraform_vars_test.go
+++ b/pkg/simulator/terraform_vars_test.go
@@ -4,6 +4,8 @@ import (
 	"github.com/controlplaneio/simulator-standalone/pkg/simulator"
 	"github.com/controlplaneio/simulator-standalone/pkg/util"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"testing"
 )
 
@@ -15,7 +17,7 @@ access_cidr = "10.0.0.1/16"
 attack_container_tag = "latest"
 state_bucket_name = "test-bucket"
 `
-	assert.Equal(t, tfv.String(), expected)
+	assert.Equal(t, expected, tfv.String())
 }
 
 func Test_Ensure_TfVarsFile_with_settings(t *testing.T) {
@@ -23,7 +25,11 @@ func Test_Ensure_TfVarsFile_with_settings(t *testing.T) {
 	varsFile := tfVarsDir + "/settings/bastion.tfVars"
 
 	err := simulator.EnsureLatestTfVarsFile(tfVarsDir, "ssh-rsa", "10.0.0.1/16", "test-bucket", "latest")
-	assert.Nil(t, err, "Got an error")
-
-	assert.Equal(t, util.MustSlurp(varsFile), "test = true\n")
+	require.NoError(t, err)
+	expected := `access_key = "ssh-rsa"
+access_cidr = "10.0.0.1/16"
+attack_container_tag = "latest"
+state_bucket_name = "test-bucket"
+`
+	assert.Equal(t, expected, util.MustSlurp(varsFile))
 }

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -3,6 +3,8 @@ package util_test
 import (
 	"github.com/controlplaneio/simulator-standalone/pkg/util"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"os"
 	"testing"
 	"time"
@@ -52,22 +54,22 @@ func Test_EnvOrDefault(t *testing.T) {
 
 func Test_ExpandTilde(t *testing.T) {
 	p, err := util.ExpandTilde("~/.")
-	assert.Nil(t, err, "Got an error")
+	require.NoError(t, err)
 
-	assert.Regexp(t, `^/home/([^/]+)$`, *p)
+	assert.Regexp(t, `^/(home|Users)/([^/]+)$`, *p)
 
 	// Call ExpandTilde again to exercise the cache
 	p2, err := util.ExpandTilde("~/.")
-	assert.Nil(t, err, "Got an error resolving tilde")
+	require.Nil(t, err, "Got an error resolving tilde")
 	assert.Equal(t, *p, *p2, "Cached version differed")
 
 	p3, err := util.ExpandTilde("fail")
-	assert.NotNil(t, err, "Didn't get an error when path didn't start with tilde slash")
+	require.NotNil(t, err, "Didn't get an error when path didn't start with tilde slash")
 	assert.Nil(t, p3, "Got a path when path didn't start with tilde slash")
 	assert.Regexp(t, `^Path was empty or did not start with a tilde and a slash:`, err.Error())
 
 	p4, err := util.ExpandTilde("")
-	assert.NotNil(t, err, "Didn't get an error for empty path")
+	require.NotNil(t, err, "Didn't get an error for empty path")
 	assert.Nil(t, p4, "Got a path when resolving an empty path")
 	assert.Regexp(t, `^Path was empty or did not start with a tilde and a slash:`, err.Error())
 }

--- a/terraform/deployments/AWS/terraform-bundle.hcl
+++ b/terraform/deployments/AWS/terraform-bundle.hcl
@@ -1,5 +1,5 @@
 terraform {
-  version = "0.12.12"
+  version = "0.12.20"
 }
 
 providers {

--- a/test/fixtures/tf-dir-with-settings/settings/bastion.tfVars
+++ b/test/fixtures/tf-dir-with-settings/settings/bastion.tfVars
@@ -1,1 +1,0 @@
-test = true

--- a/test/fixtures/tf-dir-with-settings/settings/providers.tf
+++ b/test/fixtures/tf-dir-with-settings/settings/providers.tf
@@ -1,4 +1,0 @@
-provider "aws" {}
-
-terraform { backend "s3" { } }
-


### PR DESCRIPTION
This PR fixes some issues I had while building and running tests on my box:

* Fixes home path for OSX
* Fixes failed test although I am not 100% sure about `EnsureLatestTfVarsFile` as doc + test and implementation do not match
* Upgrade terraform version as docker build failed with version incompatibility

Some other minor changes based on personal preferences:
* Replaced some `assert.Nil(t, err, "Got an error")` with `require.NoError(t, err)` -> more readable + acts like fatal.
* Flipped some arguments in `assert.Equal(t, expected, actual)` for correct output
