### PR TITLE
build: only rerun make dep if go.mod changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,8 +108,7 @@ docker-test: validate-reqs docker-build ## Run the tests
 	cd attack && make docker-test
 
 # -- SIMULATOR CLI
-.PHONY: dep
-dep: ## Install dependencies for other targets
+dep: go.mod ## Install dependencies for other targets
 	mkdir -p ~/go/bin
 	$(GO) mod download
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ~/go/bin v1.22.2


### PR DESCRIPTION
Makes the `dep` target of the `Makefile` non `.PHONY` so that it will only run if the `go.mod` file changes. 

**Steps to test**

1. run `make docker-test`
2. Make a trivial edit to a go file (eg change a comment)
3. re-run `make docker-test`

**Expected results**

On the second run of `make docker-test` the go modules do not get downloaded again