### PR TITLE
feat: add `make run-dev`, run without rebuild

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ gpg-preflight:
 
 # --- DOCKER
 run: validate-reqs docker-build ## Run the simulator - the build stage of the container runs all the cli tests
-	@docker run                                                             \
+	@docker run                                                         \
 		-h launch                                                       \
 		-v $(SIMULATOR_AWS_CREDS_PATH):/home/launch/.aws                \
 		-v $(SSH_CONFIG_PATH):/home/launch/.ssh                         \
@@ -82,7 +82,21 @@ run: validate-reqs docker-build ## Run the simulator - the build stage of the co
 		-v "$(shell pwd)/terraform":/app/terraform                      \
 		-v "$(shell pwd)/simulation-scripts":/app/simulation-scripts:ro \
 		--env-file launch-environment                                   \
-		--rm --init -it $(CONTAINER_NAME_LATEST)
+		--rm --init -it $(CONTAINER_NAME_LATEST)						\
+		$(COMMAND)
+
+run-dev: validate-reqs ## Run the simulator in dev mode without a rebuild
+	@docker run                                                         				 \
+		-h launch                                                       				 \
+		-v $(SIMULATOR_AWS_CREDS_PATH):/home/launch/.aws                				 \
+		-v $(SSH_CONFIG_PATH):/home/launch/.ssh                         				 \
+		-v $(KUBE_SIM_TMP):/home/launch/.kubesim                        				 \
+		-v "$(shell pwd)/terraform":/app/terraform                      				 \
+		-v "$(shell pwd)/simulation-scripts":/app/simulation-scripts:ro 				 \
+		-v "$(shell pwd)/launch-files/launch-entrypoint.sh":/app/launch-entrypoint.sh:ro \
+		--env-file launch-environment                                  					 \
+		--rm --init -it $(CONTAINER_NAME_LATEST)									     \
+	$(COMMAND)
 
 .PHONY: docker-build-nocache
 docker-build-nocache: ## Builds the launch container without the Docker cache

--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ dep: ## Install dependencies for other targets
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b ~/go/bin v1.22.2
 
 .PHONY: static-analysis
-static-analysis: dep
+static-analysis: dep ## Run golangci-lint
 	golangci-lint run
 
 .PHONY: build

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ create</code>
 
 ### Terraform
 
-Refer to the [simulator terraform documentation](./terraform/README.md) 
+Refer to the [simulator terraform documentation](./terraform/README.md)
 
 ### SSH
 
@@ -222,21 +222,20 @@ Development targets are specified in the [Makefile](./Makefile).
 
 <pre>
 setup-dev             Initialise simulation tree with git hooks
-devtools-deps: # Install devtools dependencies 
+devtools-deps         Install devtools dependencies
 devtools              Install devtools
-test-devtools: # Run all the unit tests for the devtools 
+test-devtools         Run all the unit tests for the devtools
 reset                 Clean up files left over by simulator
-validate-requirements  Verify all requirements are met
-previous-tag:        
-release-tag:         
-gpg-preflight:       
+validate-reqs         Verify all requirements are met
 run                   Run the simulator - the build stage of the container runs all the cli tests
-docker-build-no-cache  Builds the launch container
+run-dev               Run the simulator in dev mode without a rebuild
+docker-build-nocache  Builds the launch container without the Docker cache
 docker-build          Builds the launch container
 docker-test           Run the tests
 dep                   Install dependencies for other targets
+static-analysis       Run golangci-lint
 build                 Run golang build for the CLI program
-is-in-launch-container  checks you are running in the launch container
+is-in-launch          checks you are running in the launch container
 test                  run all tests except goss tests
 test-acceptance       Run tcl acceptance tests for the CLI program
 test-smoke            Run expect smoke test to check happy path works end-to-end
@@ -244,7 +243,7 @@ test-unit             Run golang unit tests for the CLI program
 test-cleanup          cleans up automated test artefacts if e.g. you ctrl-c abort a test run
 test-coverage         Run golang unit tests with coverage and opens a browser with the results
 docs                  Generate documentation
-release: gpg-preflight previous-tag release-tag docker-test docker-build build 
+release               Docker container and binary release automation for simulator
 </pre>
 
 ### Git commits


### PR DESCRIPTION
Mount an entrypoint into the container for fast debug cycles.

This also adds an optional "COMMAND" environment variable for scripting inside the container, and adds the latest Makefile output into README, stripping trailing ^M characters from every line



* **Please check if the PR fulfills these requirements**
- [x] The commit message follows the conventional commits guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Development/demo aid, docs

* **What is the current behavior?** (You can also link to an open issue here)
No ability to run container after minor entrypoint or script change without full rebuild/recompilation, which takes a few minutes

* **What is the new behavior (if this is a feature change)?**
Mount the changed file into the previously build container 

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Other information**:
