### PR TITLE
fix: ensure ~/.kubesim/simulator.yaml exists

### DIFF
--- a/launch-files/launch-entrypoint.sh
+++ b/launch-files/launch-entrypoint.sh
@@ -7,13 +7,19 @@ main() {
   trap show_exit_warning EXIT
   trap show_exit_warning SIGTERM
 
-  fix_aws_environment_variables
+  ensure_environment
+  ensure_kubesim_directory
 
   exec "${@:-/bin/bash}"
 }
 
-fix_aws_environment_variables() {
+ensure_environment() {
   export AWS_REGION="${AWS_REGION:-${AWS_DEFAULT_REGION:-}}"
+}
+
+ensure_kubesim_directory() {
+  mkdir -p ~/.kubesim
+  touch ~/.kubesim/simulator.yaml
 }
 
 draw_box() {


### PR DESCRIPTION
This is needed in case an empty temporary directory is passed to `make run`:

```
BUCKET=some-entropic-bucket; KUBE_SIM_TMP="/tmp/kubesim-${BUCKET}"; make run
```

* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows the conventional commits guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

* **What is the current behavior?** (You can also link to an open issue here)

* **What is the new behavior (if this is a feature change)?**

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**:
