### PR TITLE
build(attack): create release target for attack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,7 +175,7 @@ release: validate-reqs gpg-preflight previous-tag release-tag docker-test docker
 	hub release create -m $(RELEASE_TAG) -a dist/simulator $(RELEASE_TAG)
 	docker tag $(CONTAINER_NAME_LATEST) $(DOCKER_HUB_ORG)/simulator:$(RELEASE_TAG)
 	docker push $(DOCKER_HUB_ORG)/simulator:$(RELEASE_TAG)
-	cd attack && make docker-push
+	cd attack && RELEASE_TAG=$(RELEASE_TAG) make release
 
 
 # --- MAKEFILE HELP

--- a/attack/Makefile
+++ b/attack/Makefile
@@ -44,5 +44,6 @@ ifndef RELEASE_TAG
 	$(error RELEASE_TAG is undefined)
 endif
 	docker tag $(CONTAINER_NAME_LATEST) $(DOCKER_HUB_ORG)/simulator-attack:$(RELEASE_TAG)
+	docker push "${CONTAINER_NAME_LATEST}"
 	docker push $(DOCKER_HUB_ORG)/simulator-attack:$(RELEASE_TAG)
 

--- a/attack/Makefile
+++ b/attack/Makefile
@@ -39,3 +39,10 @@ docker-push: docker-test ## pushes the last build docker image
 	docker push "${CONTAINER_NAME}"
 	#docker push "${CONTAINER_NAME_LATEST}"
 
+release: docker-build
+ifndef RELEASE_TAG
+	$(error RELEASE_TAG is undefined)
+endif
+	docker tag $(CONTAINER_NAME_LATEST) $(DOCKER_HUB_ORG)/simulator-attack:$(RELEASE_TAG)
+	docker push $(DOCKER_HUB_ORG)/simulator-attack:$(RELEASE_TAG)
+


### PR DESCRIPTION
This fixes the release process to ensure an attack container tag is also always pushed with the same version as the launch container and the git release tag.

This has been tested with:

```
cd attack
RELEASE_TAG=v0.5.0 make release
```
and [there is now a `v0.5.0` tag](https://hub.docker.com/layers/controlplane/simulator-attack/v0.5.0/images/sha256-6bc660a5c8d32628ce18258602b1b05d0b58b365f957a4620da173926b72fa01) for the `simulator-attack` container which corresponds to the released `v0.5.0` tag for the launch container and git release.

Future releases will do this automatically when this is merged