### PR TITLE
Attack container docker repository configuration flag

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,15 +42,15 @@ We welcome pull requests!
 - `cd .. && make run` to run the launch container
 - `simulator infra create --attack-container-tag=super-cool-feature --attack-container-repo=<dockerhub-user>/simulator-attack`
 
-### Implementation detailsj
+### Implementation details
 
 The tag and repo are defined by Terraform variables called
 "attack_container_tag" and "attack_container_repo". The variables are threaded
 through from the deployment to the bastion and then templated into the
 cloud-config to pull the appropriate tag from the appropriate repo and launch
-that tag when the ubuntu user logs in (done by `simulator ssh attack`).
+that tag when the `ubuntu` user logs in (done by `simulator ssh attack`).
 
-The golang binary has corresponding `--attack-container-tag` and
+The Golang binary has corresponding `--attack-container-tag` and
 `--attack-container-repo` flags and configuration variables to control what
 these are set to. They are written to `tfvars` during initialisation so that
 they propagate all the way through.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,11 +38,21 @@ We welcome pull requests!
 
 - edit code in the `./attack` directory
 - commit changes on branch
-- From the root of the repo, `cd attack && CONTAINER_TAG=super-cool-feature make docker-push` to push the tagged attack container
+- From the root of the repo, `cd attack && DOCKER_HUB_ORG=<dockerhub-user> CONTAINER_TAG=super-cool-feature make docker-push` to push the tagged attack container
 - `cd .. && make run` to run the launch container
-- `simulator infra create --attack-container-tag=super-cool-feature`
+- `simulator infra create --attack-container-tag=super-cool-feature --attack-container-repo=<dockerhub-user>/simulator-attack`
 
-The tag is defined by a Terraform variable called "attack_container_tag". The variable is threaded through from the deployment to the bastion and is then templated into the cloud-config to pull the appropriate tag and launch that tag when the
-ubuntu user logs in (done by `simulator ssh attack`).
+### Implementation detailsj
 
-The golang binary has a corresponding `--attack-container-tag` flag and configuration variable to control what this is set to. This is written to `tfvars` during initialisation so that it propagates all the way through.
+The tag and repo are defined by Terraform variables called
+"attack_container_tag" and "attack_container_repo". The variables are threaded
+through from the deployment to the bastion and then templated into the
+cloud-config to pull the appropriate tag from the appropriate repo and launch
+that tag when the ubuntu user logs in (done by `simulator ssh attack`).
+
+The golang binary has corresponding `--attack-container-tag` and
+`--attack-container-repo` flags and configuration variables to control what
+these are set to. They are written to `tfvars` during initialisation so that
+they propagate all the way through.
+
+

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ NAME := simulator
 # Note these are used for the golang module name which was created before the
 # migration from controlplane's github to the kubernetes-simulator org
 GITHUB_ORG := controlplaneio
-DOCKER_HUB_ORG := controlplane
+DOCKER_HUB_ORG ?= controlplane
 GO_MODULE_NAME := simulator-standalone
 
 # --- Boilerplate

--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,6 @@ dep: go.mod ## Install dependencies for other targets
 
 .PHONY: static-analysis
 static-analysis: dep
-	ls -al
 	golangci-lint run
 
 .PHONY: build

--- a/attack/Makefile
+++ b/attack/Makefile
@@ -1,7 +1,7 @@
 NAME := simulator
 CONTAINER_BASE_NAME := simulator-attack
 GITHUB_ORG := controlplaneio
-DOCKER_HUB_ORG := controlplane
+DOCKER_HUB_ORG ?= controlplane
 VERSION := 0.1-dev
 
 LOCAL_DEV_SIMULATION := $(abspath ../simulation-scripts/scenario/etcd-inverted-wedge)

--- a/cmd/infra.go
+++ b/cmd/infra.go
@@ -23,6 +23,7 @@ func newCreateCommand(logger *zap.SugaredLogger) *cobra.Command {
 
 			scenariosDir := viper.GetString("scenarios-dir")
 			attackTag := viper.GetString("attack-container-tag")
+			attackRepo := viper.GetString("attack-container-repo")
 			tfDir := viper.GetString("tf-dir")
 			tfVarsDir := viper.GetString("tf-vars-dir")
 
@@ -33,14 +34,15 @@ func newCreateCommand(logger *zap.SugaredLogger) *cobra.Command {
 				sim.WithTfDir(tfDir),
 				sim.WithScenariosDir(scenariosDir),
 				sim.WithAttackTag(attackTag),
+				sim.WithAttackRepo(attackRepo),
 				sim.WithBucketName(bucketName),
 				sim.WithTfVarsDir(tfVarsDir))
-			
+
 			err := simulator.Create()
 			if err != nil {
 				logger.Errorw("Error creating infrastructure", zap.Error(err))
 			}
-			
+
 			cfg, err := simulator.SSHConfig()
 			if err != nil {
 				return errors.Wrap(err, "Error getting SSH config")
@@ -80,7 +82,7 @@ func newStatusCommand(logger *zap.SugaredLogger) *cobra.Command {
 				sim.WithAttackTag(attackTag),
 				sim.WithBucketName(bucketName),
 				sim.WithTfVarsDir(tfVarsDir))
-			
+
 			tfo, err := simulator.Status()
 			if err != nil {
 				logger.Errorw("Error getting status of infrastructure", zap.Error(err))

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -59,6 +59,12 @@ func newCmdRoot() *cobra.Command {
 		panic(err)
 	}
 
+	rootCmd.PersistentFlags().StringP("attack-container-repo", "a", "controlplane/simulator-attack",
+		"The attack container repo to pull pull from on the bastion")
+	if err := viper.BindPFlag("attack-container-repo", rootCmd.PersistentFlags().Lookup("attack-container-repo")); err != nil {
+		panic(err)
+	}
+
 	// TODO: (rem) this is also used to locate the perturb.sh script which may be
 	// subsumed by this app
 	rootCmd.PersistentFlags().StringP("scenarios-dir", "s", "./simulation-scripts",

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -59,7 +59,7 @@ func newCmdRoot() *cobra.Command {
 		panic(err)
 	}
 
-	rootCmd.PersistentFlags().StringP("attack-container-repo", "a", "controlplane/simulator-attack",
+	rootCmd.PersistentFlags().StringP("attack-container-repo", "r", "controlplane/simulator-attack",
 		"The attack container repo to pull pull from on the bastion")
 	if err := viper.BindPFlag("attack-container-repo", rootCmd.PersistentFlags().Lookup("attack-container-repo")); err != nil {
 		panic(err)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -60,7 +60,7 @@ func newCmdRoot() *cobra.Command {
 	}
 
 	rootCmd.PersistentFlags().StringP("attack-container-repo", "r", "controlplane/simulator-attack",
-		"The attack container repo to pull pull from on the bastion")
+		"The attack container repo to pull from on the bastion")
 	if err := viper.BindPFlag("attack-container-repo", rootCmd.PersistentFlags().Lookup("attack-container-repo")); err != nil {
 		panic(err)
 	}

--- a/pkg/simulator/simulator.go
+++ b/pkg/simulator/simulator.go
@@ -14,8 +14,11 @@ type Simulator struct {
 	// BucketName is the remote state bucket to use for terraform
 	BucketName string
 	// AttackTag is the docker tag for the attack container that terraform will use
-	// when creating the infrastructure
+	// when creating the infrastructure: e.g. latest
 	AttackTag string
+	// AttackRepo is the docker repo for the attack container that terraform will use
+	// when creating the infrastructure: e.g. controlplane/simulator-attack
+	AttackRepo string
 	// scenarioID is the unique identifier of the scenario used for the launch function
 	ScenarioID string
 	// TfVarsDir is the location to store the terraform variables file that are detected
@@ -53,6 +56,14 @@ func WithLogger(logger *zap.SugaredLogger) Option {
 func WithAttackTag(attackTag string) Option {
 	return func(s *Simulator) {
 		s.AttackTag = attackTag
+	}
+}
+
+// WithAttackRepo returns a configurer for creating a `Simulator` instance with
+// `NewSimulator`
+func WithAttackRepo(attackRepo string) Option {
+	return func(s *Simulator) {
+		s.AttackRepo = attackRepo
 	}
 }
 

--- a/pkg/simulator/terraform.go
+++ b/pkg/simulator/terraform.go
@@ -78,7 +78,7 @@ func (s *Simulator) InitIfNeeded() error {
 	s.Logger.Debugf("Access CIDR: %s", accessCIDR)
 	s.Logger.Debugf("Remote State Bucket Name: %s", s.BucketName)
 	s.Logger.Debug("Writing terraform tfvars")
-	err = EnsureLatestTfVarsFile(s.TfVarsDir, *publickey, accessCIDR, s.BucketName, s.AttackTag)
+	err = EnsureLatestTfVarsFile(s.TfVarsDir, *publickey, accessCIDR, s.BucketName, s.AttackTag, s.AttackRepo)
 	if err != nil {
 		return errors.Wrap(err, "Error writing tfvars")
 	}

--- a/pkg/simulator/terraform_vars.go
+++ b/pkg/simulator/terraform_vars.go
@@ -11,27 +11,33 @@ type TfVars struct {
 	AccessCIDR string
 	BucketName string
 	AttackTag  string
+	AttackRepo string
 }
 
 // NewTfVars creates a TfVars struct with all the defaults
-func NewTfVars(publicKey, accessCIDR, bucketName, attackTag string) TfVars {
+func NewTfVars(publicKey, accessCIDR, bucketName, attackTag, attackRepo string) TfVars {
 	return TfVars{
 		PublicKey:  publicKey,
 		AccessCIDR: accessCIDR,
 		BucketName: bucketName,
 		AttackTag:  attackTag,
+		AttackRepo: attackRepo,
 	}
 }
 
 func (tfv *TfVars) String() string {
-	return "access_key = \"" + tfv.PublicKey + "\"\n" + "access_cidr = \"" + tfv.AccessCIDR + "\"\n" + "attack_container_tag = \"" + tfv.AttackTag + "\"\n" + "state_bucket_name = \"" + tfv.BucketName + "\"\n"
+	return "access_key = \"" + tfv.PublicKey + "\"\n" +
+		"access_cidr = \"" + tfv.AccessCIDR + "\"\n" +
+		"attack_container_tag = \"" + tfv.AttackTag + "\"\n" +
+		"attack_container_repo = \"" + tfv.AttackRepo + "\"\n" +
+		"state_bucket_name = \"" + tfv.BucketName + "\"\n"
 
 }
 
 // EnsureLatestTfVarsFile always writes an tfvars file
-func EnsureLatestTfVarsFile(tfVarsDir, publicKey, accessCIDR, bucket, attackTag string) error {
+func EnsureLatestTfVarsFile(tfVarsDir, publicKey, accessCIDR, bucket, attackTag, attackRepo string) error {
 	filename := tfVarsDir + "/settings/bastion.tfvars"
-	tfv := NewTfVars(publicKey, accessCIDR, bucket, attackTag)
+	tfv := NewTfVars(publicKey, accessCIDR, bucket, attackTag, attackRepo)
 
 	return util.OverwriteFile(filename, tfv.String())
 }

--- a/pkg/simulator/terraform_vars_test.go
+++ b/pkg/simulator/terraform_vars_test.go
@@ -14,10 +14,12 @@ import (
 
 func Test_TfVars_String(t *testing.T) {
 	t.Parallel()
-	tfv := simulator.NewTfVars("ssh-rsa", "10.0.0.1/16", "test-bucket", "latest")
+	tfv := simulator.NewTfVars("ssh-rsa", "10.0.0.1/16", "test-bucket",
+		"latest", "controlplane/simulator-attack")
 	expected := `access_key = "ssh-rsa"
 access_cidr = "10.0.0.1/16"
 attack_container_tag = "latest"
+attack_container_repo = "controlplane/simulator-attack"
 state_bucket_name = "test-bucket"
 `
 	assert.Equal(t, expected, tfv.String())
@@ -33,11 +35,13 @@ func Test_Ensure_TfVarsFile_with_settings(t *testing.T) {
 	err = ioutil.WriteFile(bastionVarsFile, []byte("any=content"), 0644)
 	require.NoError(t, err)
 
-	err = simulator.EnsureLatestTfVarsFile(workDir, "ssh-rsa", "10.0.0.1/16", "test-bucket", "latest")
+	err = simulator.EnsureLatestTfVarsFile(workDir, "ssh-rsa", "10.0.0.1/16",
+		"test-bucket", "latest", "controlplane/simulator-attack")
 	require.NoError(t, err)
 	expected := `access_key = "ssh-rsa"
 access_cidr = "10.0.0.1/16"
 attack_container_tag = "latest"
+attack_container_repo = "controlplane/simulator-attack"
 state_bucket_name = "test-bucket"
 `
 	assert.Equal(t, expected, util.MustSlurp(bastionVarsFile))

--- a/terraform/deployments/AWS/main.tf
+++ b/terraform/deployments/AWS/main.tf
@@ -36,6 +36,7 @@ module "Bastion" {
   node_ip_addresses        = "${join(",", "${module.Kubernetes.K8sNodesPrivateIp}")}"
   internal_host_private_ip = "${module.InternalHost.InternalHostPrivateIp}"
   attack_container_tag     = "${var.attack_container_tag}"
+  attack_container_repo    = "${var.attack_container_repo}"
   default_tags             = "${local.aws_tags}"
 }
 

--- a/terraform/deployments/AWS/variables.tf
+++ b/terraform/deployments/AWS/variables.tf
@@ -66,6 +66,11 @@ variable "attack_container_tag" {
   default     = "latest"
 }
 
+variable "attack_container_repo" {
+  description = "the docker repo of the attack container to use"
+  default     = "controlplane/simulator-attack"
+}
+
 variable "state_bucket_name" {
   description = "name of the s3 state bucket"
   default     = "not-defined"

--- a/terraform/modules/AWS/Bastion/cloud-config.tf
+++ b/terraform/modules/AWS/Bastion/cloud-config.tf
@@ -5,6 +5,7 @@ data "template_file" "cloud_config" {
     node_ip_addresses        = var.node_ip_addresses
     internal_host_private_ip = var.internal_host_private_ip
     attack_container_tag     = var.attack_container_tag
+    attack_container_repo    = var.attack_container_repo
     bastion_bashrc           = filebase64("${path.module}/bashrc")
     bastion_inputrc          = filebase64("${path.module}/inputrc")
     bastion_aliases          = filebase64("${path.module}/bash_aliases")

--- a/terraform/modules/AWS/Bastion/cloud-config.yaml
+++ b/terraform/modules/AWS/Bastion/cloud-config.yaml
@@ -11,7 +11,7 @@ hostname: "bastion"
 runcmd:
   - "systemctl daemon-reload"
   - "systemctl restart docker"
-  - "docker pull controlplane/simulator-attack:${attack_container_tag}"
+  - "docker pull ${attack_container_repo}:${attack_container_tag}"
 
 write_files:
   - path: /etc/bash.bashrc
@@ -32,7 +32,7 @@ write_files:
       export MASTER_IP_ADDRESSES=${master_ip_addresses}
       export NODE_IP_ADDRESSES=${node_ip_addresses}
       export INTERNAL_HOST_IP=${internal_host_private_ip}
-      sudo -E docker run -h attack -v /home/ubuntu/progress.json:/progress.json -v /home/ubuntu/tasks.yaml:/tasks.yaml -v /home/ubuntu/challenge.txt:/challenge.txt -e BASE64_SSH_KEY -e MASTER_IP_ADDRESSES -e NODE_IP_ADDRESSES -e INTERNAL_HOST_IP -it controlplane/simulator-attack:${attack_container_tag}
+      sudo -E docker run -h attack -v /home/ubuntu/progress.json:/progress.json -v /home/ubuntu/tasks.yaml:/tasks.yaml -v /home/ubuntu/challenge.txt:/challenge.txt -e BASE64_SSH_KEY -e MASTER_IP_ADDRESSES -e NODE_IP_ADDRESSES -e INTERNAL_HOST_IP -it ${attack_container_repo}:${attack_container_tag}
   - path: /home/ubuntu/progress.json
     permissions: "0666"
     content: "{}"

--- a/terraform/modules/AWS/Bastion/goss-template.tf
+++ b/terraform/modules/AWS/Bastion/goss-template.tf
@@ -1,7 +1,8 @@
 data "template_file" "goss_template" {
   template = file("${path.module}/goss.yaml")
   vars = {
-    attack_container_tag = var.attack_container_tag
+    attack_container_tag  = var.attack_container_tag
+    attack_container_repo = var.attack_container_repo
   }
 }
 

--- a/terraform/modules/AWS/Bastion/goss.yaml
+++ b/terraform/modules/AWS/Bastion/goss.yaml
@@ -29,7 +29,7 @@ service:
 # Check whether we have the latest simulator-attack pulled locally
 command:
   docker:
-    exec: 'docker image inspect controlplane/simulator-attack:${attack_container_tag}'
+    exec: 'docker image inspect ${attack_container_repo}:${attack_container_tag}'
     exit-status: 0
   hostname:
     exec: "hostname | grep bastion"

--- a/terraform/modules/AWS/Bastion/variables.tf
+++ b/terraform/modules/AWS/Bastion/variables.tf
@@ -37,6 +37,10 @@ variable "attack_container_tag" {
   description = "the docker tag of the attack container to use"
 }
 
+variable "attack_container_repo" {
+  description = "the docker repo of the attack container to use"
+}
+
 variable "internal_host_private_ip" {
   description = "The Internal Host Private IP address"
 }

--- a/test/fixtures/noop-tf-dir/settings/bastion.tfvars
+++ b/test/fixtures/noop-tf-dir/settings/bastion.tfvars
@@ -1,0 +1,5 @@
+access_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCwbrmsmYpn1Kj6TYkl3O3X+2ksWNegctfEkEhWm620ypf4d5ilKjs9FuiL3X2LQKEllgNz7rNbNioDAATxrQh26d6VF9Pjzt1qBO20I/KnRI0jDT8x6FTe5x/KQp5B2H5oG81hjUFqVbjNGXZ/MNdhFtvt0Ktbu+OcnhHMbhBOQHDP0hYBrM6upbLGbQSg7ObghPBZBWOYvTXTYfKCpqm/MOQ/uAuysp/3qPkIUm/zuqClX2hlr3MGKaIl0EyjSTQ2ysj9IBQWz0qlrGgwT8/ytZiHGXp+3TB6CqJMlWzdb77AlVST5Swli6U+7TyU28nHHwfS6k8DT9o/tmC3GKtd simulator-key"
+access_cidr = "81.157.243.178/32"
+attack_container_tag = "latest"
+attack_container_repo = "latest"
+state_bucket_name = "test"


### PR DESCRIPTION
This allows anyone to create a tagged version of the attack container in their own docker hub account and then configure their simulator infra to use it.  I have pushed a version tagged `latest` to my dockerhub at `raoulmillais/simulator-attack`.

### To test the flag you can:

* checkout this branch
* `make run`
* `simulator infra create --attack-container-repo=raoulmillais/simulator-attack`
* `ssh -F ~/.ssh/cp_simulator_config bastion`
* check the `/home/ubuntu/.bash_login` file invokes docker with the correct repository

### To test the contribution flow yourself:

* `cd attack`
* `DOCKER_HUB_ORG=<dockerhub-user> CONTAINER_TAG=super-cool-feature make docker-push`
* `cd .. && make run` to run the launch container
* `simulator infra create --attack-container-tag=super-cool-feature --attack-container-repo=<dockerhub-user>/simulator-attack`

