### PR TITLE
refactor(simulator): replace zap with logrus

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,12 +1,12 @@
 package cmd
 
 import (
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"go.uber.org/zap"
 )
 
-func newConfigGetCommand(logger *zap.SugaredLogger) *cobra.Command {
+func newConfigGetCommand(logger *logrus.Logger) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   `get <key>`,
 		Short: "Gets the value of a setting",
@@ -34,13 +34,7 @@ func newConfigCommand() *cobra.Command {
 		SilenceErrors: false,
 	}
 
-	logger, err := newLogger(viper.GetString("loglevel"), "console")
-	if err != nil {
-		logger.Fatalf("can't re-initialize zap logger: %v", err)
-	}
-
-	defer logger.Sync() //nolint:errcheck
-
+	logger := newLogger(viper.GetString("loglevel"))
 	cmd.AddCommand(newConfigGetCommand(logger))
 
 	return cmd

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,9 +5,9 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"go.uber.org/zap"
 )
 
 var cfgFile string
@@ -20,7 +20,7 @@ debugging Kubernetes
 `,
 }
 
-var logger *zap.SugaredLogger //nolint:deadcode,unused
+var logger *logrus.Logger //nolint:deadcode,unused
 
 func newCmdRoot() *cobra.Command {
 	rootCmd.PersistentFlags().StringVarP(&cfgFile, "config-file", "c", "", "Path to the simulator config file")

--- a/cmd/scenario.go
+++ b/cmd/scenario.go
@@ -65,14 +65,14 @@ func newScenarioLaunchCommand(logger *logrus.Logger) *cobra.Command {
 			if err := simulator.Launch(); err != nil {
 				if strings.HasPrefix(err.Error(), "Scenario not found") {
 					logger.WithFields(logrus.Fields{
-						"error":    err,
-						"scenario": args[0],
+						"Error":    err,
+						"Scenario": args[0],
 					}).Warn("Scenario not found")
 
 					return nil
 				}
 				logger.WithFields(logrus.Fields{
-					"error": err,
+					"Error": err,
 				}).Error("Error launching scenario")
 			}
 

--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -4,12 +4,12 @@ import (
 	sim "github.com/controlplaneio/simulator-standalone/pkg/simulator"
 	"github.com/controlplaneio/simulator-standalone/pkg/ssh"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"go.uber.org/zap"
 )
 
-func newSSHConfigCommand(logger *zap.SugaredLogger) *cobra.Command {
+func newSSHConfigCommand(logger *logrus.Logger) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   `config`,
 		Short: "Prints the stanzas to add to ssh config to connect to your cluster",
@@ -40,7 +40,7 @@ func newSSHConfigCommand(logger *zap.SugaredLogger) *cobra.Command {
 			}
 
 			if !shouldwrite {
-				logger.Info(*cfg)
+				logger.Info(cfg)
 			}
 
 			err = ssh.EnsureSSHConfig(*cfg)
@@ -56,12 +56,12 @@ func newSSHConfigCommand(logger *zap.SugaredLogger) *cobra.Command {
 	return cmd
 }
 
-func newSSHAttackCommand(logger *zap.SugaredLogger) *cobra.Command {
+func newSSHAttackCommand(logger *logrus.Logger) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   `attack`,
 		Short: "Connect to an attack container to complete the scenario",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			
+
 			bucketName := viper.GetString("state-bucket")
 			attackTag := viper.GetString("attack-container-tag")
 			tfDir := viper.GetString("tf-dir")
@@ -90,11 +90,7 @@ func newSSHCommand() *cobra.Command {
 		SilenceErrors: false,
 	}
 
-	logger, err := newLogger(viper.GetString("loglevel"), "console")
-	if err != nil {
-		logger.Fatalf("can't re-initialize zap logger: %v", err)
-	}
-	defer logger.Sync() //nolint:errcheck
+	logger := newLogger(viper.GetString("loglevel"))
 
 	cmd.AddCommand(newSSHConfigCommand(logger))
 	cmd.AddCommand(newSSHAttackCommand(logger))

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -17,12 +17,7 @@ func newVersionCommand() *cobra.Command {
 		Use:   `version`,
 		Short: "Prints simulator version",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			logger, err := newLogger(viper.GetString("loglevel"), "console")
-			if err != nil {
-				logger.Fatalf("Can't re-initialize zap logger: %v", err)
-			}
-
-			defer logger.Sync() //nolint:errcheck
+			logger := newLogger(viper.GetString("loglevel"))
 
 			logger.Infof("version %s\n", version)
 			logger.Infof("git commit %s\n", commit)

--- a/go.mod
+++ b/go.mod
@@ -7,12 +7,12 @@ require (
 	github.com/magiconair/properties v1.8.1 // indirect
 	github.com/pelletier/go-toml v1.4.0 // indirect
 	github.com/pkg/errors v0.8.1
+	github.com/sirupsen/logrus v1.2.0
 	github.com/spf13/afero v1.2.2 // indirect
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/viper v1.4.0
 	github.com/stretchr/testify v1.3.0
-	go.uber.org/zap v1.10.0
 	golang.org/x/crypto v0.0.0-20190621222207-cc06ce4a13d4
 	golang.org/x/net v0.0.0-20190620200207-3b0461eec859 // indirect
 	golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb // indirect

--- a/go.sum
+++ b/go.sum
@@ -57,6 +57,7 @@ github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
@@ -88,12 +89,12 @@ github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:
 github.com/prometheus/common v0.0.0-20181113130724-41aa239b4cce/go.mod h1:daVV7qP5qjZbuso7PdcryaAu0sAZbrN9i7WWcTMWvro=
 github.com/prometheus/common v0.4.0 h1:7etb9YClo3a6HjLzfl6rIQaU+FDfi0VSX39io3aQ+DM=
 github.com/prometheus/common v0.4.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
-github.com/prometheus/common v0.7.0 h1:L+1lyG48J1zAQXA3RBX/nG/B3gjlHq0zTt2tlbJLyCY=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
+github.com/sirupsen/logrus v1.2.0 h1:juTguoYk5qI21pwyTXY3B3Y5cOTH3ZUyZCg1v/mihuo=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=

--- a/pkg/simulator/launch.go
+++ b/pkg/simulator/launch.go
@@ -14,7 +14,7 @@ import (
 // is not ready or something goes wrong
 func (s *Simulator) Launch() error {
 	s.Logger.WithFields(logrus.Fields{
-		"scenariosDir": s.ScenariosDir,
+		"ScenariosDir": s.ScenariosDir,
 	}).Debug("Loading scenario manifest")
 	manifest, err := scenario.LoadManifest(s.ScenariosDir)
 	if err != nil {
@@ -22,7 +22,7 @@ func (s *Simulator) Launch() error {
 	}
 
 	s.Logger.WithFields(logrus.Fields{
-		"scenarioID": s.ScenarioID,
+		"ScenarioID": s.ScenarioID,
 	}).Debug("Checking manifest contains scenario")
 	if !manifest.Contains(s.ScenarioID) {
 		return errors.Errorf("Scenario not found: %s", s.ScenarioID)
@@ -37,7 +37,7 @@ func (s *Simulator) Launch() error {
 	s.Logger.Debug(tfo)
 
 	s.Logger.WithFields(logrus.Fields{
-		"scenarioID": s.ScenarioID,
+		"ScenarioID": s.ScenarioID,
 	}).Infof("Finding details of scenario")
 	foundScenario := manifest.Find(s.ScenarioID)
 	s.Logger.Debug(foundScenario)

--- a/pkg/simulator/launch.go
+++ b/pkg/simulator/launch.go
@@ -6,24 +6,29 @@ import (
 	"github.com/controlplaneio/simulator-standalone/pkg/scenario"
 	"github.com/controlplaneio/simulator-standalone/pkg/ssh"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 // Launch runs perturb.sh to setup a scenario with the supplied `id` assuming
 // the infrastructure has been created.  Returns an error if the infrastructure
 // is not ready or something goes wrong
 func (s *Simulator) Launch() error {
-	s.Logger.Debugf("Loading scenario manifest from %s", s.ScenariosDir)
+	s.Logger.WithFields(logrus.Fields{
+		"scenariosDir": s.ScenariosDir,
+	}).Debug("Loading scenario manifest")
 	manifest, err := scenario.LoadManifest(s.ScenariosDir)
 	if err != nil {
 		return errors.Wrap(err, "Error loading scenario manifest file")
 	}
 
-	s.Logger.Debugf("Checking manifest contains %s", s.ScenarioID)
+	s.Logger.WithFields(logrus.Fields{
+		"scenarioID": s.ScenarioID,
+	}).Debug("Checking manifest contains scenario")
 	if !manifest.Contains(s.ScenarioID) {
 		return errors.Errorf("Scenario not found: %s", s.ScenarioID)
 	}
 
-	s.Logger.Debugf("Checking status of infrastructure")
+	s.Logger.Debug("Checking status of infrastructure")
 	tfo, _ := s.Status()
 
 	if !tfo.IsUsable() {
@@ -31,11 +36,13 @@ func (s *Simulator) Launch() error {
 	}
 	s.Logger.Debug(tfo)
 
-	s.Logger.Infof("Finding details of scenario %s", s.ScenarioID)
+	s.Logger.WithFields(logrus.Fields{
+		"scenarioID": s.ScenarioID,
+	}).Infof("Finding details of scenario")
 	foundScenario := manifest.Find(s.ScenarioID)
 	s.Logger.Debug(foundScenario)
 
-	s.Logger.Debugf(
+	s.Logger.Debug(
 		"Making options to pass to perturb from terraorm output and scnenario")
 	po := MakePerturbOptions(*tfo, foundScenario.Path)
 	s.Logger.Debug(po)
@@ -53,14 +60,18 @@ func (s *Simulator) Launch() error {
 	}
 
 	bastion := tfo.BastionPublicIP.Value
-	s.Logger.Infof("Keyscanning %s and updating known hosts", bastion)
+	s.Logger.WithFields(logrus.Fields{
+		"BastionIP": bastion,
+	}).Info("Keyscanning bastion and updating known hosts")
 	err = ssh.EnsureKnownHosts(bastion)
 	if err != nil {
 		return errors.Wrapf(err, "Error updating known hosts for bastion: %s",
 			bastion)
 	}
 
-	s.Logger.Infof("Setting up the \"%s\" scenario on the cluster", foundScenario.DisplayName)
+	s.Logger.WithFields(logrus.Fields{
+		"Scenario": foundScenario.DisplayName,
+	}).Info("Setting up the scenario on the cluster")
 	_, err = Perturb(&po)
 	if err != nil {
 		if strings.Contains(err.Error(), "exit status 103") {

--- a/pkg/simulator/remote_state.go
+++ b/pkg/simulator/remote_state.go
@@ -22,7 +22,7 @@ func CreateRemoteStateBucket(logger *logrus.Logger, bucket string) error {
 	}
 
 	logger.WithFields(logrus.Fields{
-		"bucketName": bucket,
+		"BucketName": bucket,
 	}).Info("Waiting for bucket to be created")
 	if err := svc.WaitUntilBucketExists(&s3.HeadBucketInput{
 		Bucket: aws.String(bucket),
@@ -31,7 +31,7 @@ func CreateRemoteStateBucket(logger *logrus.Logger, bucket string) error {
 	}
 
 	logger.WithFields(logrus.Fields{
-		"bucketName": bucket,
+		"BucketName": bucket,
 	}).Infof("Bucket successfully created")
 	return nil
 }

--- a/pkg/simulator/remote_state.go
+++ b/pkg/simulator/remote_state.go
@@ -5,11 +5,11 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/pkg/errors"
-	"go.uber.org/zap"
+	"github.com/sirupsen/logrus"
 )
 
 // CreateRemoteStateBucket initialises a remote-state bucket
-func CreateRemoteStateBucket(logger *zap.SugaredLogger, bucket string) error {
+func CreateRemoteStateBucket(logger *logrus.Logger, bucket string) error {
 	sess, err := session.NewSession(&aws.Config{})
 	if err != nil {
 		return err
@@ -21,13 +21,17 @@ func CreateRemoteStateBucket(logger *zap.SugaredLogger, bucket string) error {
 		return errors.Wrapf(err, "Unable to create bucket %q", bucket)
 	}
 
-	logger.Infof("Waiting for bucket %q to be created...", bucket)
+	logger.WithFields(logrus.Fields{
+		"bucketName": bucket,
+	}).Info("Waiting for bucket to be created")
 	if err := svc.WaitUntilBucketExists(&s3.HeadBucketInput{
 		Bucket: aws.String(bucket),
 	}); err != nil {
 		return errors.Wrapf(err, "Error occurred while waiting for bucket to be created, %v", bucket)
 	}
 
-	logger.Infof("Bucket %q successfully created", bucket)
+	logger.WithFields(logrus.Fields{
+		"bucketName": bucket,
+	}).Infof("Bucket successfully created")
 	return nil
 }

--- a/pkg/simulator/simulator.go
+++ b/pkg/simulator/simulator.go
@@ -1,14 +1,14 @@
 package simulator
 
 import (
-	"go.uber.org/zap"
+	"github.com/sirupsen/logrus"
 )
 
 // Simulator represents a session with simulator and holds all the configuration
 // necessary to run simulator
 type Simulator struct {
 	// Logger is the logger the simulator will use
-	Logger *zap.SugaredLogger
+	Logger *logrus.Logger
 	// TfDir is the path to the terraform code used to standup the simulator cluster
 	TfDir string
 	// BucketName is the remote state bucket to use for terraform
@@ -45,7 +45,7 @@ func NewSimulator(options ...Option) *Simulator {
 
 // WithLogger returns a configurer for creating a `Simulator` instance with
 // `NewSimulator`
-func WithLogger(logger *zap.SugaredLogger) Option {
+func WithLogger(logger *logrus.Logger) Option {
 	return func(s *Simulator) {
 		s.Logger = logger
 	}

--- a/pkg/simulator/ssh_test.go
+++ b/pkg/simulator/ssh_test.go
@@ -11,7 +11,7 @@ func Test_Config(t *testing.T) {
 	t.Skip("Need to mock out terraform output")
 	t.Parallel()
 	simulator := simulator.NewSimulator(
-		simulator.WithLogger(noopLogger),
+		simulator.WithLogger(logger),
 		simulator.WithTfDir(fixture("noop-tf-dir")),
 		simulator.WithScenariosDir(fixture("valid")),
 		simulator.WithAttackTag("Latest"),

--- a/pkg/simulator/terraform.go
+++ b/pkg/simulator/terraform.go
@@ -6,6 +6,7 @@ import (
 	"github.com/controlplaneio/simulator-standalone/pkg/ssh"
 	"github.com/controlplaneio/simulator-standalone/pkg/util"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 // PrepareTfArgs takes a string with the terraform command desired and returns
@@ -72,12 +73,13 @@ func (s *Simulator) InitIfNeeded() error {
 		return errors.Wrap(err, "Error reading public key")
 	}
 
-	s.Logger.Debugf("terraform Directory: %s", s.TfDir)
-	s.Logger.Debugf("terraform vars Directory: %s", s.TfVarsDir)
-	s.Logger.Debugf("Public Key:\n%s", publickey)
-	s.Logger.Debugf("Access CIDR: %s", accessCIDR)
-	s.Logger.Debugf("Remote State Bucket Name: %s", s.BucketName)
-	s.Logger.Debug("Writing terraform tfvars")
+	s.Logger.WithFields(logrus.Fields{
+		"TfDir":      s.TfDir,
+		"TfVarsDir":  s.TfVarsDir,
+		"PublicKey":  publickey,
+		"AccessCIDR": accessCIDR,
+		"BucketName": s.BucketName,
+	}).Debug("Writing Terraform tfvars file")
 	err = EnsureLatestTfVarsFile(s.TfVarsDir, *publickey, accessCIDR, s.BucketName, s.AttackTag, s.AttackRepo)
 	if err != nil {
 		return errors.Wrap(err, "Error writing tfvars")

--- a/pkg/simulator/terraform_test.go
+++ b/pkg/simulator/terraform_test.go
@@ -2,16 +2,17 @@ package simulator_test
 
 import (
 	sim "github.com/controlplaneio/simulator-standalone/pkg/simulator"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
-	"go.uber.org/zap"
 	"testing"
 
+	"io/ioutil"
 	"os"
 )
 
 var pwd, _ = os.Getwd()
 var testVarFileArg = "--var-file=" + pwd + "/" + fixture("noop-tf-dir") + "/settings/bastion.tfvars"
-var noopLogger = zap.NewNop().Sugar()
+var logger = logrus.New()
 
 var tfCommandArgumentsTests = []struct {
 	prepArgs  []string
@@ -25,10 +26,10 @@ var tfCommandArgumentsTests = []struct {
 }
 
 func Test_PrepareTfArgs(t *testing.T) {
-
 	pwd, _ := os.Getwd()
+	logger.Out = ioutil.Discard
 	simulator := sim.NewSimulator(
-		sim.WithLogger(noopLogger),
+		sim.WithLogger(logger),
 		sim.WithBucketName("test-bucket"),
 		sim.WithTfVarsDir(pwd+"/"+fixture("noop-tf-dir")))
 
@@ -41,8 +42,9 @@ func Test_PrepareTfArgs(t *testing.T) {
 
 func Test_Status(t *testing.T) {
 	pwd, _ := os.Getwd()
+	logger.Out = ioutil.Discard
 	simulator := sim.NewSimulator(
-		sim.WithLogger(noopLogger),
+		sim.WithLogger(logger),
 		sim.WithTfDir(fixture("noop-tf-dir")),
 		sim.WithScenariosDir("test"),
 		sim.WithAttackTag("latest"),
@@ -58,8 +60,9 @@ func Test_Status(t *testing.T) {
 func Test_Create(t *testing.T) {
 
 	pwd, _ := os.Getwd()
+	logger.Out = ioutil.Discard
 	simulator := sim.NewSimulator(
-		sim.WithLogger(noopLogger),
+		sim.WithLogger(logger),
 		sim.WithTfDir(fixture("noop-tf-dir")),
 		sim.WithScenariosDir("test"),
 		sim.WithAttackTag("latest"),
@@ -73,8 +76,9 @@ func Test_Create(t *testing.T) {
 func Test_Destroy(t *testing.T) {
 
 	pwd, _ := os.Getwd()
+	logger.Out = ioutil.Discard
 	simulator := sim.NewSimulator(
-		sim.WithLogger(noopLogger),
+		sim.WithLogger(logger),
 		sim.WithTfDir(fixture("noop-tf-dir")),
 		sim.WithAttackTag("latest"),
 		sim.WithBucketName("test"),


### PR DESCRIPTION
This is the first step in addressing the logging technical debt.  This PR migrates away from zap which is designed with microservices in mind, doesn't support pluggable transports and has weak support for [structured logging](https://stackify.com/what-is-structured-logging-and-why-developers-need-it/).

The new implementation uses [logrus](https://github.com/sirupsen/logrus) which is the most commonly used logging framework for Golang CLI apps (docker / runc etc use it).

In all places where we were previously using formatted strings for log messages, I have replaced the message  with a static string and added structured logging fields instead.

I also standardised the logging messages in some places for greater consistency.  There should be negligable impact to the end user.

This will enable us in the future to make logging more flexible and configurable with e.g. JSON output or writing logs to files etc.

This fixes #145 
