### PR TITLE
feat: add categories and difficulties to scenarios

### DIFF
--- a/simulation-scripts/scenario/container-ambush/tasks.yaml
+++ b/simulation-scripts/scenario/container-ambush/tasks.yaml
@@ -1,3 +1,5 @@
+category: container
+difficulty: Easy
 kind: cp.simulator/scenario:1.0.0
 objective: Get postgres password.
 startingPoint:

--- a/simulation-scripts/scenario/container-defeat-in-detail/tasks.yaml
+++ b/simulation-scripts/scenario/container-defeat-in-detail/tasks.yaml
@@ -1,3 +1,5 @@
+category: container
+difficulty: Medium
 kind: cp.simulator/scenario:1.0.0
 objective: Exec into a container on master with certificates mounted in to exploit
   etcd.

--- a/simulation-scripts/scenario/container-phalanx-formation/tasks.yaml
+++ b/simulation-scripts/scenario/container-phalanx-formation/tasks.yaml
@@ -1,3 +1,5 @@
+category: container
+difficulty: Easy
 kind: cp.simulator/scenario:1.0.0
 objective: Find a secret in a log file.
 startingPoint:

--- a/simulation-scripts/scenario/etcd-inverted-wedge/tasks.yaml
+++ b/simulation-scripts/scenario/etcd-inverted-wedge/tasks.yaml
@@ -1,3 +1,5 @@
+category: etcd
+difficulty: Hard
 kind: cp.simulator/scenario:1.0.0
 objective: Discover uncertified etcd, reach it with only network access and master
   node IP. Fix the leakage.

--- a/simulation-scripts/scenario/master-encirclement/tasks.yaml
+++ b/simulation-scripts/scenario/master-encirclement/tasks.yaml
@@ -1,3 +1,5 @@
+category: master
+difficulty: Medium
 kind: cp.simulator/scenario:1.0.0
 objective: Enable MutatingAdmissionWebhook admission controller in the API server.
 startingPoint:

--- a/simulation-scripts/scenario/master-shell-scrape/tasks.yaml
+++ b/simulation-scripts/scenario/master-shell-scrape/tasks.yaml
@@ -1,3 +1,5 @@
+category: master
+difficulty: Medium
 kind: cp.simulator/scenario:1.0.0
 objective: API is enabled on --insecure-bind-address and --insecure-port
 startingPoint:

--- a/simulation-scripts/scenario/network-feint/tasks.yaml
+++ b/simulation-scripts/scenario/network-feint/tasks.yaml
@@ -1,3 +1,5 @@
+category: network
+difficulty: Medium
 kind: cp.simulator/scenario:1.0.0
 objective: Use misconfigured svc to compromise db.
 startingPoint:

--- a/simulation-scripts/scenario/network-hammer-and-anvil/tasks.yaml
+++ b/simulation-scripts/scenario/network-hammer-and-anvil/tasks.yaml
@@ -1,3 +1,5 @@
+category: network
+difficulty: Medium
 kind: cp.simulator/scenario:1.0.0
 objective: Use badly configured database to exfiltrate data.
 startingPoint:

--- a/simulation-scripts/scenario/network-hedgehog-defence/tasks.yaml
+++ b/simulation-scripts/scenario/network-hedgehog-defence/tasks.yaml
@@ -1,3 +1,5 @@
+category: network
+difficulty: Medium
 kind: cp.simulator/scenario:1.0.0
 objective: Compromised database from outside namespace.
 startingPoint:

--- a/simulation-scripts/scenario/network-swarming/tasks.yaml
+++ b/simulation-scripts/scenario/network-swarming/tasks.yaml
@@ -1,3 +1,5 @@
+category: network
+difficulty: Easy
 kind: cp.simulator/scenario:1.0.0
 objective: Use misconfigured svc to compromise db.
 startingPoint:

--- a/simulation-scripts/scenario/node-amphibious-operations/tasks.yaml
+++ b/simulation-scripts/scenario/node-amphibious-operations/tasks.yaml
@@ -1,3 +1,5 @@
+category: node
+difficulty: Hard
 kind: cp.simulator/scenario:1.0.0
 objective: Node compromise to get unauth kubelet API access.
 startingPoint:

--- a/simulation-scripts/scenario/node-raiding/tasks.yaml
+++ b/simulation-scripts/scenario/node-raiding/tasks.yaml
@@ -1,3 +1,5 @@
+category: node
+difficulty: Medium
 kind: cp.simulator/scenario:1.0.0
 objective: Node compromise to get readonly kubelet API access.
 startingPoint:

--- a/simulation-scripts/scenario/node-shock-tactics/tasks.yaml
+++ b/simulation-scripts/scenario/node-shock-tactics/tasks.yaml
@@ -1,3 +1,5 @@
+category: node
+difficulty: Medium
 kind: cp.simulator/scenario:1.0.0
 objective: Node escalation to workload compromise.
 startingPoint:

--- a/simulation-scripts/scenario/noop/tasks.yaml
+++ b/simulation-scripts/scenario/noop/tasks.yaml
@@ -1,3 +1,5 @@
+category: noop
+difficulty: null
 kind: cp.simulator/scenario:1.0.0
 objective: Do nothing
 startingPoint: ""

--- a/simulation-scripts/scenario/policy-echelon-formation/tasks.yaml
+++ b/simulation-scripts/scenario/policy-echelon-formation/tasks.yaml
@@ -1,3 +1,5 @@
+category: policy
+difficulty: Hard
 kind: cp.simulator/scenario:1.0.0
 objective: Use privileged container to get host secrets.
 startingPoint:

--- a/simulation-scripts/scenario/policy-fire-support/tasks.yaml
+++ b/simulation-scripts/scenario/policy-fire-support/tasks.yaml
@@ -1,3 +1,5 @@
+category: policy
+difficulty: Easy
 kind: cp.simulator/scenario:1.0.0
 objective: Use Sudo to get un readable ssh keys from a host mount.
 startingPoint:

--- a/simulation-scripts/scenario/policy-force-dispersal/tasks.yaml
+++ b/simulation-scripts/scenario/policy-force-dispersal/tasks.yaml
@@ -1,3 +1,5 @@
+category: policy
+difficulty: Medium
 kind: cp.simulator/scenario:1.0.0
 objective: Enable PodSecurityPolicy in the API server.
 startingPoint:

--- a/simulation-scripts/scenario/policy-vertical-envelopment/tasks.yaml
+++ b/simulation-scripts/scenario/policy-vertical-envelopment/tasks.yaml
@@ -1,3 +1,5 @@
+category: policy
+difficulty: Medium
 kind: cp.simulator/scenario:1.0.0
 objective: Use privileged container to get host secrets.
 startingPoint:

--- a/simulation-scripts/scenario/rbac-contact-drill/tasks.yaml
+++ b/simulation-scripts/scenario/rbac-contact-drill/tasks.yaml
@@ -1,3 +1,5 @@
+category: rbac
+difficulty: Easy
 kind: cp.simulator/scenario:1.0.0
 objective: Figure out additional permissions given to the default service account
   and reassign to designated role.

--- a/simulation-scripts/scenario/rbac-flanking-maneuver/tasks.yaml
+++ b/simulation-scripts/scenario/rbac-flanking-maneuver/tasks.yaml
@@ -1,3 +1,5 @@
+category: rbac
+difficulty: Hard
 kind: cp.simulator/scenario:1.0.0
 objective: SSH into vulnerable workload, wget secrets using permissive SA.
 startingPoint:

--- a/simulation-scripts/scenario/rbac-sangar/tasks.yaml
+++ b/simulation-scripts/scenario/rbac-sangar/tasks.yaml
@@ -1,3 +1,5 @@
+category: rbac
+difficulty: Easy
 kind: cp.simulator/scenario:1.0.0
 objective: Figure out additional permissions given to system:authenticated group and
   remove them.

--- a/simulation-scripts/scenario/rbac-shoot-and-scoot/tasks.yaml
+++ b/simulation-scripts/scenario/rbac-shoot-and-scoot/tasks.yaml
@@ -1,3 +1,5 @@
+category: rbac
+difficulty: Easy
 kind: cp.simulator/scenario:1.0.0
 objective: Figure out additional permissions given to system:anonymous role and remove
   them.

--- a/simulation-scripts/scenario/secret-high-ground/tasks.yaml
+++ b/simulation-scripts/scenario/secret-high-ground/tasks.yaml
@@ -1,3 +1,5 @@
+category: secret
+difficulty: Easy
 kind: cp.simulator/scenario:1.0.0
 objective: Fix a pull policy and then add a secret to the pod.
 startingPoint:

--- a/simulation-scripts/scenario/secret-tank-desant/tasks.yaml
+++ b/simulation-scripts/scenario/secret-tank-desant/tasks.yaml
@@ -1,3 +1,5 @@
+category: secret
+difficulty: Easy
 kind: cp.simulator/scenario:1.0.0
 objective: Compromise secret from running workload.
 startingPoint:

--- a/simulation-scripts/tools/add-category-and-difficulty.sh
+++ b/simulation-scripts/tools/add-category-and-difficulty.sh
@@ -1,10 +1,11 @@
 #! /bin/bash
+# APPEARS TO BROKEN DO NOT USE
 # This script will find the category and difficulty of each scenario and add these values to new fields in the tasks.yaml.
-for dir in simulation-scripts/scenario/*/; do
-    echo "${dir}"
-    category=$(echo "${dir}" | cut -f3 -d"/" | cut -f1 -d"-")
-    difficulty=$(grep Difficulty "${dir}"challenge.txt | cut -f2 -d":" | tr -d " ")
-    echo "${category} ${difficulty}"
-    new_yaml=$(yq r -j "${dir}"tasks.yaml | jq --arg CATEGORY "${category}" '. |= .+{"category": $CATEGORY}' | jq --arg DIFFICULTY "${difficulty}" '. |= .+{"difficulty": $DIFFICULTY}' | yq r - | yq r -j - | jq '.' | yq r -)
-    echo "${new_yaml}" >"${dir}"tasks.yaml
-done
+# for dir in simulation-scripts/scenario/*/; do
+#     echo "${dir}"
+#     category=$(echo "${dir}" | cut -f3 -d"/" | cut -f1 -d"-")
+#     difficulty=$(grep Difficulty "${dir}"challenge.txt | cut -f2 -d":" | tr -d " ")
+#     echo "${category} ${difficulty}"
+#     new_yaml=$(yq r -j "${dir}"tasks.yaml | jq --arg CATEGORY "${category}" '. |= .+{"category": $CATEGORY}' | jq --arg DIFFICULTY "${difficulty}" '. |= .+{"difficulty": $DIFFICULTY}' | yq r - | yq r -j - | jq '.' | yq r -)
+#     echo "${new_yaml}" >"${dir}"tasks.yaml
+# done

--- a/simulation-scripts/tools/add-category-and-difficulty.sh
+++ b/simulation-scripts/tools/add-category-and-difficulty.sh
@@ -1,0 +1,11 @@
+#! /bin/bash
+# This script will add a penalty value to each hint object.
+# In order to update all penalty values, simply re-run the script with the new value replacing '10'. This may cause some cosmetic key reordering in the final yaml.
+for dir in simulation-scripts/scenario/*/; do
+    echo "${dir}"
+    category=$(echo "${dir}" | cut -f3 -d"/" | cut -f1 -d"-")
+    difficulty=$(cat "${dir}"challenge.txt | grep Difficulty | cut -f2 -d":" | tr -d " ")
+    echo "${category} ${difficulty}"
+    new_yaml=$(yq r -j "${dir}"tasks.yaml | jq --arg CATEGORY "${category}" '. |= .+{"category": $CATEGORY}' | jq --arg DIFFICULTY "${difficulty}" '. |= .+{"difficulty": $DIFFICULTY}' | yq r - | yq r -j - | jq '.' | yq r -)
+    echo "${new_yaml}" >"${dir}"tasks.yaml
+done

--- a/simulation-scripts/tools/add-category-and-difficulty.sh
+++ b/simulation-scripts/tools/add-category-and-difficulty.sh
@@ -4,7 +4,7 @@
 for dir in simulation-scripts/scenario/*/; do
     echo "${dir}"
     category=$(echo "${dir}" | cut -f3 -d"/" | cut -f1 -d"-")
-    difficulty=$(cat "${dir}"challenge.txt | grep Difficulty | cut -f2 -d":" | tr -d " ")
+    difficulty=$(grep Difficulty "${dir}"challenge.txt | cut -f2 -d":" | tr -d " ")
     echo "${category} ${difficulty}"
     new_yaml=$(yq r -j "${dir}"tasks.yaml | jq --arg CATEGORY "${category}" '. |= .+{"category": $CATEGORY}' | jq --arg DIFFICULTY "${difficulty}" '. |= .+{"difficulty": $DIFFICULTY}' | yq r - | yq r -j - | jq '.' | yq r -)
     echo "${new_yaml}" >"${dir}"tasks.yaml

--- a/simulation-scripts/tools/add-category-and-difficulty.sh
+++ b/simulation-scripts/tools/add-category-and-difficulty.sh
@@ -1,6 +1,5 @@
 #! /bin/bash
-# This script will add a penalty value to each hint object.
-# In order to update all penalty values, simply re-run the script with the new value replacing '10'. This may cause some cosmetic key reordering in the final yaml.
+# This script will find the category and difficulty of each scenario and add these values to new fields in the tasks.yaml.
 for dir in simulation-scripts/scenario/*/; do
     echo "${dir}"
     category=$(echo "${dir}" | cut -f3 -d"/" | cut -f1 -d"-")


### PR DESCRIPTION
Add new fields to the tasks.yaml to document the category and difficulty of each scenario.

Resolves #208, resolves #210 