### PR TITLE
feat: allow extra ips to be added to the bastion sg

### DIFF
--- a/cmd/infra.go
+++ b/cmd/infra.go
@@ -27,6 +27,7 @@ func newCreateCommand(logger *logrus.Logger) *cobra.Command {
 			tfDir := viper.GetString("tf-dir")
 			tfVarsDir := viper.GetString("tf-vars-dir")
 			disableIPDetection := viper.GetBool("disable-ip-detection")
+			extraCIDRs := viper.GetString("extra-cidrs")
 
 			logger.WithFields(logrus.Fields{
 				"BucketName": bucketName,
@@ -40,7 +41,8 @@ func newCreateCommand(logger *logrus.Logger) *cobra.Command {
 				sim.WithAttackRepo(attackRepo),
 				sim.WithBucketName(bucketName),
 				sim.WithoutIPDetection(disableIPDetection),
-				sim.WithTfVarsDir(tfVarsDir))
+				sim.WithTfVarsDir(tfVarsDir),
+				sim.WithExtraCIDRs(extraCIDRs))
 
 			err := simulator.Create()
 			if err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -48,7 +48,7 @@ func newCmdRoot() *cobra.Command {
 		panic(err)
 	}
 
-	rootCmd.PersistentFlags().StringP("category", "g", "",
+	rootCmd.PersistentFlags().StringP("category", "f", "",
 		"Sorts the list of scenarios by only showing scenarios of specified category")
 	if err := viper.BindPFlag("category", rootCmd.PersistentFlags().Lookup("category")); err != nil {
 		panic(err)
@@ -74,6 +74,12 @@ func newCmdRoot() *cobra.Command {
 	rootCmd.PersistentFlags().StringP("attack-container-repo", "r", "controlplane/simulator-attack",
 		"The attack container repo to pull from on the bastion")
 	if err := viper.BindPFlag("attack-container-repo", rootCmd.PersistentFlags().Lookup("attack-container-repo")); err != nil {
+		panic(err)
+	}
+
+	rootCmd.PersistentFlags().StringP("extra-cidrs", "e", "",
+		"Extra CIDRs that will be allowed to access to the bastion host. MUST be a valid CIDR and a list MUST be comma delimited")
+	if err := viper.BindPFlag("extra-cidrs", rootCmd.PersistentFlags().Lookup("extra-cidrs")); err != nil {
 		panic(err)
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -48,7 +48,7 @@ func newCmdRoot() *cobra.Command {
 		panic(err)
 	}
 
-	rootCmd.PersistentFlags().StringP("category", "f", "",
+	rootCmd.PersistentFlags().StringP("category", "g", "",
 		"Sorts the list of scenarios by only showing scenarios of specified category")
 	if err := viper.BindPFlag("category", rootCmd.PersistentFlags().Lookup("category")); err != nil {
 		panic(err)

--- a/pkg/simulator/simulator.go
+++ b/pkg/simulator/simulator.go
@@ -29,6 +29,9 @@ type Simulator struct {
 	ScenariosDir string
 	// disableIPDetection enables IP checks used for cidr access. Enabled by default.
 	DisableIPDetection bool
+	// Extra CIDRs to be added to the bastion security group to allow SSH from arbitrary
+	// locations
+	ExtraCIDRs string
 }
 
 // Option is a type used to configure a `Simulator` instance
@@ -114,5 +117,13 @@ func WithBucketName(bucketName string) Option {
 func WithoutIPDetection(disableIPDetection bool) Option {
 	return func(s *Simulator) {
 		s.DisableIPDetection = disableIPDetection
+	}
+}
+
+// WithExtraCIDRs returns a configurer for creating a `Simulator` instance with
+// `NewSimulator`
+func WithExtraCIDRs(extraCIDRs string) Option {
+	return func(s *Simulator) {
+		s.ExtraCIDRs = extraCIDRs
 	}
 }

--- a/pkg/simulator/terraform.go
+++ b/pkg/simulator/terraform.go
@@ -91,8 +91,9 @@ func (s *Simulator) InitIfNeeded() error {
 		"PublicKey":  publickey,
 		"AccessCIDR": accessCIDR,
 		"BucketName": s.BucketName,
+		"ExtraCIDRs": s.ExtraCIDRs,
 	}).Debug("Writing Terraform tfvars file")
-	err = EnsureLatestTfVarsFile(s.TfVarsDir, *publickey, accessCIDR, s.BucketName, s.AttackTag, s.AttackRepo)
+	err = EnsureLatestTfVarsFile(s.TfVarsDir, *publickey, accessCIDR, s.BucketName, s.AttackTag, s.AttackRepo, s.ExtraCIDRs)
 	if err != nil {
 		return errors.Wrap(err, "Error writing tfvars")
 	}

--- a/pkg/simulator/terraform_vars.go
+++ b/pkg/simulator/terraform_vars.go
@@ -1,6 +1,8 @@
 package simulator
 
 import (
+	"strings"
+
 	"github.com/controlplaneio/simulator-standalone/pkg/util"
 )
 
@@ -12,32 +14,42 @@ type TfVars struct {
 	BucketName string
 	AttackTag  string
 	AttackRepo string
+	ExtraCIDRs string
 }
 
 // NewTfVars creates a TfVars struct with all the defaults
-func NewTfVars(publicKey, accessCIDR, bucketName, attackTag, attackRepo string) TfVars {
+func NewTfVars(publicKey, accessCIDR, bucketName, attackTag, attackRepo, extraCIDRs string) TfVars {
 	return TfVars{
 		PublicKey:  publicKey,
 		AccessCIDR: accessCIDR,
 		BucketName: bucketName,
 		AttackTag:  attackTag,
 		AttackRepo: attackRepo,
+		ExtraCIDRs: extraCIDRs,
 	}
 }
 
 func (tfv *TfVars) String() string {
+	if tfv.ExtraCIDRs != "" {
+		splitCIDRs := strings.Split(tfv.ExtraCIDRs, ",")
+		for i := range splitCIDRs {
+			splitCIDRs[i] = strings.TrimSpace(splitCIDRs[i])
+		}
+		templatedCIDRs := strings.Join(splitCIDRs, "\", \"")
+		tfv.AccessCIDR = tfv.AccessCIDR + "\", \"" + templatedCIDRs
+	}
+
 	return "access_key = \"" + tfv.PublicKey + "\"\n" +
-		"access_cidr = \"" + tfv.AccessCIDR + "\"\n" +
+		"access_cidr = [\"" + tfv.AccessCIDR + "\"]\n" +
 		"attack_container_tag = \"" + tfv.AttackTag + "\"\n" +
 		"attack_container_repo = \"" + tfv.AttackRepo + "\"\n" +
 		"state_bucket_name = \"" + tfv.BucketName + "\"\n"
-
 }
 
 // EnsureLatestTfVarsFile always writes an tfvars file
-func EnsureLatestTfVarsFile(tfVarsDir, publicKey, accessCIDR, bucket, attackTag, attackRepo string) error {
+func EnsureLatestTfVarsFile(tfVarsDir, publicKey, accessCIDR, bucket, attackTag, attackRepo, extraCIDRs string) error {
 	filename := tfVarsDir + "/settings/bastion.tfvars"
-	tfv := NewTfVars(publicKey, accessCIDR, bucket, attackTag, attackRepo)
+	tfv := NewTfVars(publicKey, accessCIDR, bucket, attackTag, attackRepo, extraCIDRs)
 
 	return util.OverwriteFile(filename, tfv.String())
 }

--- a/pkg/simulator/terraform_vars_test.go
+++ b/pkg/simulator/terraform_vars_test.go
@@ -15,9 +15,9 @@ import (
 func Test_TfVars_String(t *testing.T) {
 	t.Parallel()
 	tfv := simulator.NewTfVars("ssh-rsa", "10.0.0.1/16", "test-bucket",
-		"latest", "controlplane/simulator-attack")
+		"latest", "controlplane/simulator-attack", "10.0.0.1/16")
 	expected := `access_key = "ssh-rsa"
-access_cidr = "10.0.0.1/16"
+access_cidr = ["10.0.0.1/16", "10.0.0.1/16"]
 attack_container_tag = "latest"
 attack_container_repo = "controlplane/simulator-attack"
 state_bucket_name = "test-bucket"
@@ -36,10 +36,10 @@ func Test_Ensure_TfVarsFile_with_settings(t *testing.T) {
 	require.NoError(t, err)
 
 	err = simulator.EnsureLatestTfVarsFile(workDir, "ssh-rsa", "10.0.0.1/16",
-		"test-bucket", "latest", "controlplane/simulator-attack")
+		"test-bucket", "latest", "controlplane/simulator-attack", "10.0.0.1/16, 10.0.0.1/32")
 	require.NoError(t, err)
 	expected := `access_key = "ssh-rsa"
-access_cidr = "10.0.0.1/16"
+access_cidr = ["10.0.0.1/16", "10.0.0.1/16", "10.0.0.1/32"]
 attack_container_tag = "latest"
 attack_container_repo = "controlplane/simulator-attack"
 state_bucket_name = "test-bucket"

--- a/terraform/deployments/AWS/variables.tf
+++ b/terraform/deployments/AWS/variables.tf
@@ -7,6 +7,7 @@ variable "access_key" {
 
 variable "access_cidr" {
   description = "cidr range of client connection"
+  type        = list(string)
 }
 
 // Variables below are to have defined defaults

--- a/terraform/modules/AWS/SecurityGroups/main.tf
+++ b/terraform/modules/AWS/SecurityGroups/main.tf
@@ -11,26 +11,32 @@ resource "aws_security_group" "simulator_bastion_sg" {
   name   = "simulator-bastion-sg-${random_uuid.unique.result}"
   vpc_id = var.vpc_id
 
-  ingress {
-    protocol    = "tcp"
-    from_port   = 22
-    to_port     = 22
-    cidr_blocks = [var.access_cidr]
-  }
-
-  egress {
-    protocol    = -1
-    from_port   = 0
-    to_port     = 0
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-
   tags = merge(
     var.default_tags,
     {
       "Name" = "Simulator Bastion Security Group"
     },
   )
+}
+
+resource "aws_security_group_rule" "allow_all_egress" {
+  type        = "egress"
+  from_port   = 0
+  to_port     = 0
+  protocol    = -1
+  cidr_blocks = ["0.0.0.0/0"]
+
+  security_group_id = aws_security_group.simulator_bastion_sg.id
+}
+
+resource "aws_security_group_rule" "allow_user_ip_ssh" {
+  type        = "ingress"
+  protocol    = "tcp"
+  from_port   = 22
+  to_port     = 22
+  cidr_blocks = var.access_cidr
+
+  security_group_id = aws_security_group.simulator_bastion_sg.id
 }
 
 // Private subnet security group

--- a/terraform/modules/AWS/SecurityGroups/variables.tf
+++ b/terraform/modules/AWS/SecurityGroups/variables.tf
@@ -1,5 +1,6 @@
 variable "access_cidr" {
   description = "cidr range of client connection"
+  type        = list(string)
 }
 
 variable "vpc_id" {
@@ -18,4 +19,3 @@ variable "default_tags" {
   description = "Default tags for all resources"
   type        = map(string)
 }
-


### PR DESCRIPTION
Users can now specify CIDRs to be added to the bastion security group with the `--extra-cidrs` flag.

Resolves #164 