### PR TITLE
feat: allow specific container and pod host starts

### DIFF
--- a/attack/scripts/bashrc
+++ b/attack/scripts/bashrc
@@ -141,8 +141,15 @@ starting_point() {
   elif [[ "$MODE" == "pod" ]]; then
     POD_NAME="$(echo "${task_json}" | jq -r --arg TASK_NO "${task_no}" '.tasks | .[$TASK_NO] | .startingPoint.podName')"
     POD_NS="$(echo "${task_json}" | jq -r --arg TASK_NO "${task_no}" '.tasks | .[$TASK_NO] | .startingPoint.podNamespace')"
-    # shellcheck disable=SC2029
-    ssh -tt "$INTERNAL_HOST_IP" "kubectl exec -it -n ${POD_NS} ${POD_NAME} bash"
+    CONTAINER_NAME="$(echo "${task_json}" | jq -r --arg TASK_NO "${task_no}" '.tasks | .[$TASK_NO] | .startingPoint.containerName')"
+
+    if [[ ${CONTAINER_NAME} != "null" ]]; then
+      # shellcheck disable=SC2029
+      ssh -tt "$INTERNAL_HOST_IP" "kubectl exec -it -n ${POD_NS} -c ${CONTAINER_NAME} ${POD_NAME} bash"
+    else
+      # shellcheck disable=SC2029
+      ssh -tt "$INTERNAL_HOST_IP" "kubectl exec -it -n ${POD_NS} ${POD_NAME} bash"
+    fi
 
   #Determine if mode is attack.
   elif [[ "$MODE" == "attack" ]]; then

--- a/docs/tasks-yaml-format.md
+++ b/docs/tasks-yaml-format.md
@@ -83,8 +83,24 @@ User exec's into a specific pod:
 ```YAML
 startingPoint:
   mode: pod
-  podName: "compromised-pod"
-  podNamespace: "default"
+  podName: compromised-pod
+  podNamespace: default
+```
+
+The pod starting point can also use two optional fields:
+
+* `containerName` to choose a specific container in a pod to start in. This is required for multi-container pods.
+* `podHost` to choose a pod on a specific host. Options are one of `master-0`, `node-0` or `node-1`. It is recommended to use this option with a `DaemonSet` as it can be guaranteed that a pod exists on your chosen host.
+
+A starting point using these options is below:
+
+```YAML
+startingPoint:
+  mode: pod
+  podName: compromised-pod
+  podNamespace: default
+  containerName: container-2
+  podHost: node-0
 ```
 
 Default behaviour:


### PR DESCRIPTION
Allow users to specify `podHost` and `containerName` in the `tasks.yaml` `startingPoint`. This will allow scenarios to start in multi-container pods and in pods on a specific node.

Resolves #227 
Resolves #218 
