### PR TITLE
fix: added logout to .bash_login

### DIFF
--- a/terraform/modules/AWS/Bastion/cloud-config.yaml
+++ b/terraform/modules/AWS/Bastion/cloud-config.yaml
@@ -33,6 +33,7 @@ write_files:
       export NODE_IP_ADDRESSES=${node_ip_addresses}
       export INTERNAL_HOST_IP=${internal_host_private_ip}
       sudo -E docker run -h attack -v /home/ubuntu/progress.json:/progress.json -v /home/ubuntu/tasks.yaml:/tasks.yaml -v /home/ubuntu/challenge.txt:/challenge.txt -e BASE64_SSH_KEY -e MASTER_IP_ADDRESSES -e NODE_IP_ADDRESSES -e INTERNAL_HOST_IP -it ${attack_container_repo}:${attack_container_tag}
+      logout
   - path: /home/ubuntu/progress.json
     permissions: "0666"
     content: "{}"


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix
* **What is the current behavior?** (You can also link to an open issue here)
#234 
* **What is the new behavior (if this is a feature change)?**
When exiting from attack container you are now returned to launch container

