### PR TITLE
Don't mount kubesim folder for tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,6 @@ docker-test: validate-reqs docker-build ## Run the tests
 	@export AWS_DEFAULT_REGION="testing propagation to AWS_REGION var"; \
 	docker run                                                          \
 		-v "$(SIMULATOR_AWS_CREDS_PATH)":/home/launch/.aws          \
-		-v $(KUBE_SIM_TMP):/home/launch/.kubesim                    \
 		--env-file launch-environment                               \
 		--rm -t $(CONTAINER_NAME_LATEST)                            \
 		/app/test-acceptance.sh

--- a/test/infra.test
+++ b/test/infra.test
@@ -6,6 +6,7 @@ namespace eval ::simulator::test {
 
   variable BEFORE {
     catch { unset result }
+    spawn mkdir -p /home/launch/.kubesim/settings/
     set env(SIMULATOR_TF_DIR) "./test/fixtures/noop-tf-dir"
     set env(SIMULATOR_STATE_BUCKET) "dummy-test-bucket"
     set env(SIMULATOR_CLI_TEST_OUTPUT) "./test/test.debug"


### PR DESCRIPTION
The `~/.kubesim` folder is not needed when running the tests and it is a pain to arrange for it be there when running in jenkins.  This will fix the jenkins build