### PR TITLE
fix: create parent directory before create file in OverwriteFile

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -154,6 +154,9 @@ func EnsureFile(path, contents string) (bool, error) {
 // OverwriteFile writes the supplied contents overwriting the path if it
 // already exists.  It returns an error if any occurred
 func OverwriteFile(path, contents string) error {
+	if err := os.MkdirAll(filepath.Dir(path), os.ModePerm); err != nil {
+		return err
+	}
 	file, err := os.Create(path)
 	if err != nil {
 		return err


### PR DESCRIPTION
First of all, I want to provide my deep respect for this project. It is a fantastic project. 

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows the conventional commits guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the current behavior?** (You can also link to an open issue here)
Fail to create `.kubesim/settings/bastion.tfvars` at first time.

* **What is the new behavior (if this is a feature change)?**
Create `.kubesim/settings` dir before create `./kubesim/settings/bastion.tfvars`

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:
