### PR TITLE
feat: add force option to simulator scenario launch

### DIFF
--- a/cmd/scenario.go
+++ b/cmd/scenario.go
@@ -61,7 +61,6 @@ func newScenarioListCommand(logger *logrus.Logger) *cobra.Command {
 			return nil
 		},
 	}
-
 	return cmd
 }
 
@@ -131,6 +130,9 @@ func newScenarioLaunchCommand(logger *logrus.Logger) *cobra.Command {
 			tfDir := viper.GetString("tf-dir")
 			disableIPDetection := viper.GetBool("disable-ip-detection")
 			tfVarsDir := viper.GetString("tf-vars-dir")
+			perturbOpt := sim.PerturbOptions{
+				Force: viper.GetBool("force"),
+			}
 
 			simulator := sim.NewSimulator(
 				sim.WithLogger(logger),
@@ -142,7 +144,7 @@ func newScenarioLaunchCommand(logger *logrus.Logger) *cobra.Command {
 				sim.WithoutIPDetection(disableIPDetection),
 				sim.WithTfVarsDir(tfVarsDir))
 
-			if err := simulator.Launch(); err != nil {
+			if err := simulator.Launch(perturbOpt); err != nil {
 				if strings.HasPrefix(err.Error(), "Scenario not found") {
 					logger.WithFields(logrus.Fields{
 						"Error":    err,
@@ -158,6 +160,11 @@ func newScenarioLaunchCommand(logger *logrus.Logger) *cobra.Command {
 
 			return nil
 		},
+	}
+	cmd.PersistentFlags().BoolP("force", "f", false,
+		"If true, force launches a new scenario")
+	if err := viper.BindPFlag("force", cmd.PersistentFlags().Lookup("force")); err != nil {
+		panic(err)
 	}
 
 	return cmd

--- a/pkg/simulator/launch.go
+++ b/pkg/simulator/launch.go
@@ -3,16 +3,17 @@ package simulator
 import (
 	"strings"
 
-	"github.com/controlplaneio/simulator-standalone/pkg/scenario"
-	"github.com/controlplaneio/simulator-standalone/pkg/ssh"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+
+	"github.com/controlplaneio/simulator-standalone/pkg/scenario"
+	"github.com/controlplaneio/simulator-standalone/pkg/ssh"
 )
 
 // Launch runs perturb.sh to setup a scenario with the supplied `id` assuming
 // the infrastructure has been created.  Returns an error if the infrastructure
 // is not ready or something goes wrong
-func (s *Simulator) Launch() error {
+func (s *Simulator) Launch(po PerturbOptions) error {
 	s.Logger.WithFields(logrus.Fields{
 		"ScenariosDir": s.ScenariosDir,
 	}).Debug("Loading scenario manifest")
@@ -44,7 +45,7 @@ func (s *Simulator) Launch() error {
 
 	s.Logger.Debug(
 		"Making options to pass to perturb from terraorm output and scnenario")
-	po := MakePerturbOptions(*tfo, foundScenario.Path)
+	po.MakePerturbOptions(*tfo, foundScenario.Path)
 	s.Logger.Debug(po)
 
 	s.Logger.Debug("Regenerating SSH config")

--- a/pkg/simulator/perturb_external_test.go
+++ b/pkg/simulator/perturb_external_test.go
@@ -1,0 +1,18 @@
+package simulator_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/controlplaneio/simulator-standalone/pkg/simulator"
+)
+
+func Test_Perturb(t *testing.T) {
+	os.Setenv("SIMULATOR_SCENARIOS_DIR", fixture("noop-perturb"))
+	po := simulator.PerturbOptions{}
+	_, err := simulator.Perturb(&po, logrus.New())
+	assert.NoError(t, err)
+}

--- a/pkg/simulator/perturb_test.go
+++ b/pkg/simulator/perturb_test.go
@@ -1,54 +1,79 @@
-package simulator_test
+package simulator
 
 import (
 	"net"
-	"os"
 	"testing"
 
-	"github.com/controlplaneio/simulator-standalone/pkg/simulator"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 
 func Test_ToArguments_And_String(t *testing.T) {
 	t.Parallel()
-	po := simulator.PerturbOptions{
-		Bastion: net.IPv4(127, 0, 0, 1),
-		Master:  net.IPv4(127, 0, 0, 1),
-		Slaves:  []net.IP{net.IPv4(8, 8, 8, 8), net.IPv4(127, 0, 0, 2)},
+	tests := []struct {
+		name     string
+		bastion  net.IP
+		master   net.IP
+		slaves   []net.IP
+		force    bool
+		expexted string
+	}{
+		{
+			name:     "base",
+			bastion:  net.IPv4(127, 0, 0, 1),
+			master:   net.IPv4(127, 0, 0, 1),
+			slaves:   []net.IP{net.IPv4(8, 8, 8, 8), net.IPv4(127, 0, 0, 2)},
+			expexted: "--master 127.0.0.1 --bastion 127.0.0.1 --nodes 8.8.8.8,127.0.0.2",
+		},
+		{
+			name:     "single slave",
+			bastion:  net.IPv4(127, 0, 0, 1),
+			master:   net.IPv4(127, 0, 0, 1),
+			slaves:   []net.IP{net.IPv4(8, 8, 8, 8)},
+			expexted: "--master 127.0.0.1 --bastion 127.0.0.1 --nodes 8.8.8.8",
+		},
+		{
+			name:     "with force",
+			bastion:  net.IPv4(127, 0, 0, 1),
+			master:   net.IPv4(127, 0, 0, 1),
+			slaves:   []net.IP{net.IPv4(8, 8, 8, 8), net.IPv4(127, 0, 0, 2)},
+			force:    true,
+			expexted: "--master 127.0.0.1 --bastion 127.0.0.1 --nodes 8.8.8.8,127.0.0.2 --force",
+		},
 	}
-
-	assert.Equal(t, po.String(), "--master 127.0.0.1 --bastion 127.0.0.1 --nodes 8.8.8.8,127.0.0.2")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			po := PerturbOptions{
+				bastion: tt.bastion,
+				master:  tt.master,
+				slaves:  tt.slaves,
+				Force:   tt.force,
+			}
+			assert.Equal(t, tt.expexted, po.String())
+		})
+	}
 }
 
 func Test_MakePerturbOptions(t *testing.T) {
 	t.Parallel()
-	tfo := simulator.TerraformOutput{
-		BastionPublicIP: simulator.StringOutput{
+	tfo := TerraformOutput{
+		BastionPublicIP: StringOutput{
 			Value: "127.0.0.1",
 		},
-		MasterNodesPrivateIP: simulator.StringSliceOutput{
+		MasterNodesPrivateIP: StringSliceOutput{
 			Value: []string{"127.0.0.1"},
 		},
-		ClusterNodesPrivateIP: simulator.StringSliceOutput{
+		ClusterNodesPrivateIP: StringSliceOutput{
 			Value: []string{"127.0.0.2"},
 		},
 	}
 
 	path := "./scenario/test"
 
-	po := simulator.MakePerturbOptions(tfo, path)
+	po := PerturbOptions{}
+	po.MakePerturbOptions(tfo, path)
 
-	assert.Equal(t, po.Bastion.String(), tfo.BastionPublicIP.Value)
-	assert.Equal(t, po.Master.String(), tfo.MasterNodesPrivateIP.Value[0])
-	assert.Equal(t, po.Slaves[0].String(), tfo.ClusterNodesPrivateIP.Value[0])
+	assert.Equal(t, po.bastion.String(), tfo.BastionPublicIP.Value)
+	assert.Equal(t, po.master.String(), tfo.MasterNodesPrivateIP.Value[0])
+	assert.Equal(t, po.slaves[0].String(), tfo.ClusterNodesPrivateIP.Value[0])
 
-}
-
-func Test_Perturb(t *testing.T) {
-	os.Setenv("SIMULATOR_SCENARIOS_DIR", fixture("noop-perturb"))
-	po := simulator.PerturbOptions{}
-	_, err := simulator.Perturb(&po, logrus.New())
-
-	assert.Nil(t, err, "Got an error")
 }


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows the conventional commits guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

feature for #261 

* **What is the current behavior?** (You can also link to an open issue here)
#261 

* **What is the new behavior (if this is a feature change)?**

We can run a new scenario with `--force` option.
But I do not think it is the best solution.

```
launch@launch:/app[0]$ simulator scenario launch secret-tank-desant
...
INFO[2020-02-28T07:57:40Z] [./perturb.sh] Installed scenario found: secret-high-ground$
ERRO[2020-02-28T07:57:40Z] Scenario secret-high-ground already deployed  Args="[--master 172.31.2.142 --bastion 54.199.232.73 --nodes 172.31.2.25,172.31.2.63 secret-tank-desant]" Command=./perturb.sh
ERRO[2020-02-28T07:57:40Z] Scenario clash error from perturb.sh

launch@launch:/app[0]$ simulator scenario launch --force secret-tank-desant
...
# ... launch new  scenario...
```

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**:

I changed some PerturbOptions properties to non-exported properties because I think that IPs should not be updated by other packages. How do you think about it?
