### PR TITLE
Push to Latest on Release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -169,6 +169,8 @@ release: validate-reqs gpg-preflight previous-tag release-tag docker-test docker
 	hub release create -m $(RELEASE_TAG) -a dist/simulator $(RELEASE_TAG)
 	docker tag $(CONTAINER_NAME_LATEST) $(DOCKER_HUB_ORG)/simulator:$(RELEASE_TAG)
 	docker push $(DOCKER_HUB_ORG)/simulator:$(RELEASE_TAG)
+	docker tag $(CONTAINER_NAME_LATEST) $(DOCKER_HUB_ORG)/simulator:latest
+	docker push $(DOCKER_HUB_ORG)/simulator:latest
 	cd attack && RELEASE_TAG=$(RELEASE_TAG) make release
 
 

--- a/attack/Makefile
+++ b/attack/Makefile
@@ -44,6 +44,7 @@ ifndef RELEASE_TAG
 	$(error RELEASE_TAG is undefined)
 endif
 	docker tag $(CONTAINER_NAME_LATEST) $(DOCKER_HUB_ORG)/simulator-attack:$(RELEASE_TAG)
-	docker push "${CONTAINER_NAME_LATEST}"
 	docker push $(DOCKER_HUB_ORG)/simulator-attack:$(RELEASE_TAG)
+	docker tag $(CONTAINER_NAME_LATEST) $(DOCKER_HUB_ORG)/simulator-attack:latest
+	docker push $(DOCKER_HUB_ORG)/simulator-attack:latest
 

--- a/kubesim
+++ b/kubesim
@@ -16,14 +16,15 @@ touch "${SIMULATOR_CONFIG_FILE}"
 
 docker pull ${CONTAINER_NAME}
 
-docker run                                                          \
-  -h launch                                                         \
-  -v "${SIMULATOR_AWS_CREDS_PATH}":/home/launch/.aws                \
-  -v "${KUBE_SIM_TMP}":/home/launch/.kubesim                        \
-  -e "AWS_ACCESS_KEY_ID"                                            \
-  -e "AWS_SECRET_ACCESS_KEY"                                        \
-  -e "AWS_REGION"                                                   \
-  -e "AWS_DEFAULT_REGION"                                           \
-  -e "AWS_PROFILE"                                                  \
-  -e "AWS_DEFAULT_PROFILE"                                          \
+docker run \
+  -h launch \
+  -v "${SIMULATOR_AWS_CREDS_PATH}":/home/launch/.aws \
+  -v "${KUBE_SIM_TMP}":/home/launch/.kubesim \
+  -v "${KUBE_SIM_TMP}":/home/launch/.ssh \
+  -e "AWS_ACCESS_KEY_ID" \
+  -e "AWS_SECRET_ACCESS_KEY" \
+  -e "AWS_REGION" \
+  -e "AWS_DEFAULT_REGION" \
+  -e "AWS_PROFILE" \
+  -e "AWS_DEFAULT_PROFILE" \
   --rm --init -it ${CONTAINER_NAME}


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows the conventional commits guidelines

Also push to `latest` in Docker when doing a release. This will ensure users will use the latest version of the container when running in Docker without setting a tag.

Also includes a minor volume mount fix for the `kubesim` script.
