### PR TITLE
feat: reduce the checks and output of terraform

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -252,7 +252,8 @@ COPY --chown=1000 ${config_file} /home/launch/.kubesim/
 COPY --chown=1000 launch-files/bashrc /home/launch/.bashrc
 
 ENV SIMULATOR_SCENARIOS_DIR=/app/simulation-scripts/ \
-    SIMULATOR_TF_DIR=/app/terraform/deployments/AWS
+    SIMULATOR_TF_DIR=/app/terraform/deployments/AWS \
+    DISABLE_CHECKPOINT=true
 
 USER ${launch_user}
 

--- a/pkg/simulator/terraform.go
+++ b/pkg/simulator/terraform.go
@@ -35,6 +35,10 @@ func (s *Simulator) PrepareTfArgs(cmd string) []string {
 		arguments = append(arguments, "-auto-approve")
 	}
 
+	if cmd == "apply" || cmd == "plan" {
+		arguments = append(arguments, "-compact-warnings")
+	}
+
 	return arguments
 }
 

--- a/pkg/simulator/terraform_test.go
+++ b/pkg/simulator/terraform_test.go
@@ -22,8 +22,8 @@ var tfCommandArgumentsTests = []struct {
 }{
 	{[]string{"output"}, []string{"output", "-json"}},
 	{[]string{"init"}, []string{"init", "-input=false", testVarFileArg, "-backend-config=bucket=test-bucket"}},
-	{[]string{"plan"}, []string{"plan", "-input=false", testVarFileArg}},
-	{[]string{"apply"}, []string{"apply", "-input=false", testVarFileArg, "-auto-approve"}},
+	{[]string{"plan"}, []string{"plan", "-input=false", testVarFileArg, "-compact-warnings"}},
+	{[]string{"apply"}, []string{"apply", "-input=false", testVarFileArg, "-auto-approve", "-compact-warnings"}},
 	{[]string{"destroy"}, []string{"destroy", "-input=false", testVarFileArg, "-auto-approve"}},
 }
 


### PR DESCRIPTION
Fixes #238 by setting `-compact-warnings` for terraform `apply` and `plan` commands as well as setting `DISABLE_CHECKPOINT` in the launch container.
