### PR TITLE
feat: non global commands

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -3,13 +3,14 @@ package cmd
 import (
 	"bufio"
 	"fmt"
+	"os"
+	"strings"
+
 	"github.com/kubernetes-simulator/simulator/pkg/simulator"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"os"
-	"strings"
 )
 
 func saveBucketConfig(logger *logrus.Logger, bucket string) {
@@ -40,7 +41,7 @@ func newInitCommand() *cobra.Command {
 				fmt.Print("Please choose a globally unique name for an S3 bucket to store the terraform state: ")
 				bucket, err := reader.ReadString('\n')
 				if err != nil {
-					return errors.Wrap(err, "Error reading bucket nbame from stdin")
+					return errors.Wrap(err, "Error reading bucket name from stdin")
 				}
 
 				bucket = strings.TrimSpace(bucket)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -36,76 +36,14 @@ func newCmdRoot() *cobra.Command {
 
 	// NOTE the panics here are needed - if these calls fail we cannot recover
 	// and the cause is most likely programmer error
-	rootCmd.PersistentFlags().StringP("state-bucket", "b", "",
-		"The name of the s3 bucket to use for remote-state.  Must be globally unique")
-	if err := viper.BindPFlag("state-bucket", rootCmd.PersistentFlags().Lookup("state-bucket")); err != nil {
-		panic(err)
-	}
-
-	rootCmd.PersistentFlags().StringP("difficulty", "d", "",
-		"Sorts the list of scenarios by only showing scenarios of specified difficulty")
-	if err := viper.BindPFlag("difficulty", rootCmd.PersistentFlags().Lookup("difficulty")); err != nil {
-		panic(err)
-	}
-
-	rootCmd.PersistentFlags().StringP("category", "g", "",
-		"Sorts the list of scenarios by only showing scenarios of specified category")
-	if err := viper.BindPFlag("category", rootCmd.PersistentFlags().Lookup("category")); err != nil {
-		panic(err)
-	}
-
 	rootCmd.PersistentFlags().StringP("loglevel", "l", "info", "Level of detail in output logging")
 	if err := viper.BindPFlag("loglevel", rootCmd.PersistentFlags().Lookup("loglevel")); err != nil {
 		panic(err)
 	}
 
-	rootCmd.PersistentFlags().StringP("tf-dir", "t", "./terraform/deployments/AWS",
-		"Path to a directory containing the infrastructure scripts")
-	if err := viper.BindPFlag("tf-dir", rootCmd.PersistentFlags().Lookup("tf-dir")); err != nil {
-		panic(err)
-	}
-
-	rootCmd.PersistentFlags().StringP("attack-container-tag", "a", "latest",
-		"The attack container tag to pull on the bastion")
-	if err := viper.BindPFlag("attack-container-tag", rootCmd.PersistentFlags().Lookup("attack-container-tag")); err != nil {
-		panic(err)
-	}
-
-	rootCmd.PersistentFlags().StringP("attack-container-repo", "r", "controlplane/simulator-attack",
-		"The attack container repo to pull from on the bastion")
-	if err := viper.BindPFlag("attack-container-repo", rootCmd.PersistentFlags().Lookup("attack-container-repo")); err != nil {
-		panic(err)
-	}
-
-	rootCmd.PersistentFlags().StringP("extra-cidrs", "e", "",
-		"Extra CIDRs that will be allowed to access to the bastion host. MUST be a valid CIDR and a list MUST be comma delimited")
-	if err := viper.BindPFlag("extra-cidrs", rootCmd.PersistentFlags().Lookup("extra-cidrs")); err != nil {
-		panic(err)
-	}
-
-	rootCmd.PersistentFlags().StringP("github-usernames", "u", "",
-		"Github usernames that will be allowed access to the bastion host. MUST be a valid username and a list MUST be comma delimited")
-	if err := viper.BindPFlag("github-usernames", rootCmd.PersistentFlags().Lookup("github-usernames")); err != nil {
-		panic(err)
-	}
-
-	// TODO: (rem) this is also used to locate the perturb.sh script which may be
-	// subsumed by this app
-	rootCmd.PersistentFlags().StringP("scenarios-dir", "s", "./simulation-scripts",
-		"Path to a directory containing a scenario manifest")
-	if err := viper.BindPFlag("scenarios-dir", rootCmd.PersistentFlags().Lookup("scenarios-dir")); err != nil {
-		panic(err)
-	}
-
-	rootCmd.PersistentFlags().StringP("tf-vars-dir", "v", "/home/launch/.kubesim",
-		"Path to a directory containing the terraform variables file")
-	if err := viper.BindPFlag("tf-vars-dir", rootCmd.PersistentFlags().Lookup("tf-vars-dir")); err != nil {
-		panic(err)
-	}
-
-	rootCmd.PersistentFlags().BoolP("disable-ip-detection", "i", false,
-		"Disable public IP check. If you disable, make sure you know what you are doing.")
-	if err := viper.BindPFlag("disable-ip-detection", rootCmd.PersistentFlags().Lookup("disable-ip-detection")); err != nil {
+	rootCmd.PersistentFlags().StringP("state-bucket", "b", "",
+		"The name of the s3 bucket to use for remote-state.  Must be globally unique")
+	if err := viper.BindPFlag("state-bucket", rootCmd.PersistentFlags().Lookup("state-bucket")); err != nil {
 		panic(err)
 	}
 

--- a/cmd/scenario.go
+++ b/cmd/scenario.go
@@ -125,22 +125,12 @@ func newScenarioLaunchCommand(logger *logrus.Logger) *cobra.Command {
 		Args:  cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 
-			bucketName := viper.GetString("state-bucket")
 			scenariosDir := viper.GetString("scenarios-dir")
-			attackTag := viper.GetString("attack-container-tag")
-			tfDir := viper.GetString("tf-dir")
-			disableIPDetection := viper.GetBool("disable-ip-detection")
-			tfVarsDir := viper.GetString("tf-vars-dir")
 
 			simulator := sim.NewSimulator(
 				sim.WithLogger(logger),
-				sim.WithTfDir(tfDir),
 				sim.WithScenariosDir(scenariosDir),
-				sim.WithAttackTag(attackTag),
-				sim.WithScenarioID(args[0]),
-				sim.WithBucketName(bucketName),
-				sim.WithoutIPDetection(disableIPDetection),
-				sim.WithTfVarsDir(tfVarsDir))
+				sim.WithScenarioID(args[0]))
 
 			if err := simulator.Launch(); err != nil {
 				if strings.HasPrefix(err.Error(), "Scenario not found") {
@@ -169,6 +159,24 @@ func newScenarioCommand() *cobra.Command {
 		Short:         "Interact with scenarios",
 		SilenceUsage:  true,
 		SilenceErrors: false,
+	}
+
+	cmd.PersistentFlags().StringP("scenarios-dir", "s", "./simulation-scripts",
+		"Path to a directory containing a scenario manifest")
+	if err := viper.BindPFlag("scenarios-dir", rootCmd.PersistentFlags().Lookup("scenarios-dir")); err != nil {
+		panic(err)
+	}
+
+	cmd.PersistentFlags().StringP("difficulty", "d", "",
+		"Sorts the list of scenarios by only showing scenarios of specified difficulty")
+	if err := viper.BindPFlag("difficulty", rootCmd.PersistentFlags().Lookup("difficulty")); err != nil {
+		panic(err)
+	}
+
+	cmd.PersistentFlags().StringP("category", "g", "",
+		"Sorts the list of scenarios by only showing scenarios of specified category")
+	if err := viper.BindPFlag("category", rootCmd.PersistentFlags().Lookup("category")); err != nil {
+		panic(err)
 	}
 
 	logger := newLogger(viper.GetString("loglevel"))

--- a/cmd/ssh.go
+++ b/cmd/ssh.go
@@ -15,19 +15,13 @@ func newSSHConfigCommand(logger *logrus.Logger) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			bucketName := viper.GetString("state-bucket")
-			scenariosDir := viper.GetString("scenarios-dir")
-			attackTag := viper.GetString("attack-container-tag")
 			tfDir := viper.GetString("tf-dir")
 			tfVarsDir := viper.GetString("tf-vars-dir")
-			disableIPDetection := viper.GetBool("disable-ip-detection")
 
 			simulator := sim.NewSimulator(
 				sim.WithLogger(logger),
 				sim.WithTfDir(tfDir),
-				sim.WithScenariosDir(scenariosDir),
-				sim.WithAttackTag(attackTag),
 				sim.WithBucketName(bucketName),
-				sim.WithoutIPDetection(disableIPDetection),
 				sim.WithTfVarsDir(tfVarsDir))
 
 			cfg, err := simulator.SSHConfig()
@@ -91,6 +85,18 @@ func newSSHCommand() *cobra.Command {
 		Short:         "Interact with the cluster",
 		SilenceUsage:  true,
 		SilenceErrors: false,
+	}
+
+	cmd.PersistentFlags().StringP("tf-vars-dir", "v", "/home/launch/.kubesim",
+		"Path to a directory containing the terraform variables file")
+	if err := viper.BindPFlag("tf-vars-dir", rootCmd.PersistentFlags().Lookup("tf-vars-dir")); err != nil {
+		panic(err)
+	}
+
+	cmd.PersistentFlags().StringP("tf-dir", "t", "./terraform/deployments/AWS",
+		"Path to a directory containing the infrastructure scripts")
+	if err := viper.BindPFlag("tf-dir", rootCmd.PersistentFlags().Lookup("tf-dir")); err != nil {
+		panic(err)
 	}
 
 	logger := newLogger(viper.GetString("loglevel"))


### PR DESCRIPTION
Tidy up flags so Simulator commands have their own flags:

All Commands:
"loglevel"
"config-file"
"state-bucket"

infra
"disable-ip-detection"
"tf-dir"
"tf-vars-dir"
"attack-container-tag"
"github-usernames"
"extra-cidrs"

scenario
"scenarios-dir"
"difficulty"
"category"

ssh
"tf-dir"
"tf-vars-dir"