### PR TITLE
Updating yq parameter

### DIFF
--- a/simulation-scripts/perturb.sh
+++ b/simulation-scripts/perturb.sh
@@ -339,7 +339,7 @@ template_tasks() {
   local pod_name
   local POD_NAME
   local POD_RESULT
-  tasks_json=$(yq r -j tasks.yaml)
+  tasks_json=$(yq eval -j tasks.yaml)
   cp tasks.yaml "${tmptasks}"
   POD_NAME=$(echo "${tasks_json}" | jq -r '.tasks[].startingPoint.podName | select (.!=null)')
   for pod_name in $POD_NAME; do


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] The commit message follows the conventional commits guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix: yq syntax is invalid with new versions

* **What is the current behavior?** (You can also link to an open issue here)

```
ERRO[2021-01-01T19:52:13Z] Error: unknown command "r" for "yq"           Args="[--master 172.31.2.249 --bastion 54.215.239.74 --nodes 172.31.2.101,172.31.2.115 container-ambush]" Command=./perturb.sh
ERRO[2021-01-01T19:52:13Z] Run 'yq --help' for usage.                    Args="[--master 172.31.2.249 --bastion 54.215.239.74 --nodes 172.31.2.101,172.31.2.115 container-ambush]" Command=./perturb.sh
ERRO[2021-01-01T19:52:13Z] Error launching scenario                      Error="Error running perturb with simulator.PerturbOptions{Bastion:net.IP{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff, 0xff, 0x36, 0xd7, 0xef, 0x4a}, Master:net.IP{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff, 0xff, 0xac, 0x1f, 0x2, 0xf9}, Slaves:[]net.IP{net.IP{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff, 0xff, 0xac, 0x1f, 0x2, 0x65}, net.IP{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff, 0xff, 0xac, 0x1f, 0x2, 0x73}}, ScenarioName:\"container-ambush\"}: Error waiting for child process ./perturb.sh: exit status 1"
```
* **What is the new behavior (if this is a feature change)?**

Scenario runs

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**:
yq --version
yq version 4.2.0