### PR TITLE
feat: Don't require the use of docker group

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,8 @@ HOST := $(shell hostname)
 TOOLS_DIR := tools/scenario-tools
 SIMULATOR_TFVAR_DIR := $(KUBE_SIM_TMP)/settings
 
+DOCKER := sudo docker
+
 export GOSUMDB=off
 
 # --- Make
@@ -79,7 +81,7 @@ gpg-preflight:
 
 # --- DOCKER
 run: validate-reqs docker-build ## Run the simulator - the build stage of the container runs all the cli tests
-	@docker run                                                             \
+	@$(DOCKER) run                                                             \
 		-h launch                                                       \
 		-v $(SIMULATOR_AWS_CREDS_PATH):/home/launch/.aws                \
 		-v $(KUBE_SIM_TMP):/home/launch/.kubesim                        \
@@ -94,7 +96,7 @@ docker-build-nocache: ## Builds the launch container without the Docker cache
 	@touch ~/.kubesim/simulator.yaml
 	@mkdir -p $(SIMULATOR_TFVAR_DIR)
 	@touch $(SIMULATOR_TFVAR_DIR)/bastion.tfvars
-	@docker build --no-cache -t $(CONTAINER_NAME_LATEST) .
+	@$(DOCKER) build --no-cache -t $(CONTAINER_NAME_LATEST) .
 
 .PHONY: docker-build
 docker-build: ## Builds the launch container
@@ -102,12 +104,12 @@ docker-build: ## Builds the launch container
 	@touch ~/.kubesim/simulator.yaml
 	@mkdir -p $(SIMULATOR_TFVAR_DIR)
 	@touch $(SIMULATOR_TFVAR_DIR)/bastion.tfvars
-	@docker build -t $(CONTAINER_NAME_LATEST) .
+	@$(DOCKER) build -t $(CONTAINER_NAME_LATEST) .
 
 .PHONY: docker-test
 docker-test: validate-reqs docker-build ## Run the tests
 	@export AWS_DEFAULT_REGION="testing propagation to AWS_REGION var"; \
-	docker run                                                          \
+	$(DOCKER) run                                                          \
 		-v "$(SIMULATOR_AWS_CREDS_PATH)":/home/launch/.aws          \
 		--env-file launch-environment                               \
 		--rm -t $(CONTAINER_NAME_LATEST)                            \
@@ -175,10 +177,10 @@ release: validate-reqs gpg-preflight previous-tag release-tag docker-test docker
 	git push origin $(RELEASE_TAG)
 	hub release create -F $(TMP_FILE) -a dist/simulator -a kubesim $(RELEASE_TAG)
 	rm -rf $(TMP_FILE)
-	docker tag $(CONTAINER_NAME_LATEST) $(DOCKER_HUB_ORG)/simulator:$(RELEASE_TAG)
-	docker push $(DOCKER_HUB_ORG)/simulator:$(RELEASE_TAG)
-	docker tag $(CONTAINER_NAME_LATEST) $(DOCKER_HUB_ORG)/simulator:latest
-	docker push $(DOCKER_HUB_ORG)/simulator:latest
+	$(DOCKER) tag $(CONTAINER_NAME_LATEST) $(DOCKER_HUB_ORG)/simulator:$(RELEASE_TAG)
+	$(DOCKER) push $(DOCKER_HUB_ORG)/simulator:$(RELEASE_TAG)
+	$(DOCKER) tag $(CONTAINER_NAME_LATEST) $(DOCKER_HUB_ORG)/simulator:latest
+	$(DOCKER) push $(DOCKER_HUB_ORG)/simulator:latest
 	cd attack && RELEASE_TAG=$(RELEASE_TAG) make release
 
 

--- a/scripts/validate-requirements
+++ b/scripts/validate-requirements
@@ -26,7 +26,7 @@ fi
 
 echo -n "Checking Docker is running.."
 
-if [[ $(docker version) ]]; then
+if [[ $(sudo docker version) ]]; then
 	echo "running"
 else
 	echo "not running"


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows the conventional commits guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feat: Don't require the use of docker group, all local invocations of docker are prepended with sudo.

* **What is the current behavior?** (You can also link to an open issue here)
Current scripts assume the use of docker group, which may not be configured for all users

* **What is the new behavior (if this is a feature change)?**
Default to using docker through `sudo` command, which should work for all users. Docker group users can revert to using just sudo-less `docker` more easily in the Makefile.
