### PR TITLE
feat: add internal node to generated sshconfig

### DIFF
--- a/pkg/simulator/terraform_output_test.go
+++ b/pkg/simulator/terraform_output_test.go
@@ -58,6 +58,11 @@ func Test_ToSSHConfig(t *testing.T) {
 			Type:      []interface{}{},
 			Value:     []string{"127.0.0.2", "127.0.0.3"},
 		},
+		InternalNodePrivateIP: simulator.StringOutput{
+			Sensitive: false,
+			Type:      "string",
+			Value:     "127.0.0.4",
+		},
 	}
 	expected := `Host bastion 8.8.8.8
   Hostname 8.8.8.8
@@ -81,6 +86,13 @@ Host node-0 127.0.0.2
   ProxyJump bastion
 Host node-1 127.0.0.3
   Hostname 127.0.0.3
+  User root
+  RequestTTY force
+  IdentityFile ~/.kubesim/cp_simulator_rsa
+  UserKnownHostsFile ~/.kubesim/cp_simulator_known_hosts
+  ProxyJump bastion
+Host internal 127.0.0.4
+  Hostname 127.0.0.4
   User root
   RequestTTY force
   IdentityFile ~/.kubesim/cp_simulator_rsa


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows the conventional commits guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR adds the "internal" node SSH config to the bundle generated by the simulator cli.

* **What is the current behavior?** (You can also link to an open issue here)
Simulator cli currently does not generate the internal SSH config, only the bastion and nodes.

* **What is the new behavior (if this is a feature change)?**
The internal node SSH configuration is appended to the main SSH config file.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no
