### PR TITLE
fix: ensure failed deployments return false

### DIFF
--- a/terraform/modules/AWS/Bastion/test.tf
+++ b/terraform/modules/AWS/Bastion/test.tf
@@ -30,6 +30,7 @@ resource "null_resource" "bastion_test" {
 
   provisioner "remote-exec" {
     inline = [
+      "set -o errexit",
       "chmod +x /root/run-goss.sh",
       "/root/run-goss.sh",
       "rm /root/run-goss.sh /root/goss.yaml",

--- a/terraform/modules/AWS/InternalHost/test.tf
+++ b/terraform/modules/AWS/InternalHost/test.tf
@@ -26,6 +26,7 @@ resource "null_resource" "internal_host_test" {
 
   provisioner "remote-exec" {
     inline = [
+      "set -o errexit",
       "chmod +x /root/run-goss.sh",
       "/root/run-goss.sh",
       "rm /root/run-goss.sh /root/goss.yaml",

--- a/terraform/modules/AWS/Kubernetes/test.tf
+++ b/terraform/modules/AWS/Kubernetes/test.tf
@@ -31,6 +31,7 @@ resource "null_resource" "master_test" {
 
   provisioner "remote-exec" {
     inline = [
+      "set -o errexit",
       "chmod +x /root/run-goss.sh",
       "/root/run-goss.sh",
       "rm /root/run-goss.sh /root/goss.yaml",
@@ -71,6 +72,7 @@ resource "null_resource" "node_test" {
 
   provisioner "remote-exec" {
     inline = [
+      "set -o errexit",
       "chmod +x /root/run-goss.sh",
       "/root/run-goss.sh",
       "rm /root/run-goss.sh /root/goss.yaml",

--- a/terraform/modules/scripts/run-goss.sh
+++ b/terraform/modules/scripts/run-goss.sh
@@ -20,7 +20,9 @@ readonly GOSS_VERSION=v0.3.7
 main() {
   install_goss
   wait_for_cloud_init
-  goss validate -f documentation
+  goss validate -f documentation \
+    --sleep 10s \
+    --retry-timeout 120s
 }
 readonly -f main
 


### PR DESCRIPTION
cherry-picked from private/pull/16

* **Please check if the PR fulfills these requirements**
- [x] The commit message follows the conventional commits guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bugfix

* **What is the current behavior?** (You can also link to an open issue here)
goss failures are undetected

* **What is the new behavior (if this is a feature change)?**
fix: ensure the goss fails the terraform run if it fails

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no
